### PR TITLE
hwmon fan setting

### DIFF
--- a/include/linux/mfd/macsmc.h
+++ b/include/linux/mfd/macsmc.h
@@ -83,6 +83,7 @@ static inline int apple_smc_read_flag(struct apple_smc *smc, smc_key key)
 #define apple_smc_write_flag apple_smc_write_u8
 
 int apple_smc_read_f32_scaled(struct apple_smc *smc, smc_key key, int *p, int scale);
+int apple_smc_write_f32_scaled(struct apple_smc *smc, smc_key key, int p, int scale);
 int apple_smc_read_ioft_scaled(struct apple_smc *smc, smc_key key, u64 *p, int scale);
 
 int apple_smc_register_notifier(struct apple_smc *smc, struct notifier_block *n);


### PR DESCRIPTION
Using the standard hwmon interface, it is now possible to manually set the fan speed for any enumerated fans hanging off the SMC.

Attempting to set the fan speed to 0 will restore automatic control. Additionally, it is not possible to set a fan speed outside of the safe range reported by the SMC (reported in the fan hwmon min/max attributes). It is also not possible to turn the fans off manually for safety reasons. The SMC will turn them off opportunistically when they are under automatic control.

Currently, this functionality is gated behind an unsafe module parameter.