### PR TITLE
Switch to 16-bit writes for summit panel brightness adjustment

### DIFF
--- a/drivers/gpu/drm/adp/panel-summit.c
+++ b/drivers/gpu/drm/adp/panel-summit.c
@@ -13,8 +13,8 @@ static int summit_set_brightness(struct device *dev)
 {
 	struct summit_data *panel = dev_get_drvdata(dev);
 	int level = backlight_get_brightness(panel->bl);
-	ssize_t err = mipi_dsi_dcs_write(panel->dsi, MIPI_DCS_SET_DISPLAY_BRIGHTNESS,
-					 &level, 1);
+	int err = mipi_dsi_dcs_set_display_brightness(panel->dsi, level);
+
 	if (err < 0)
 		return err;
 	return 0;
@@ -70,10 +70,10 @@ static int summit_resume(struct device *dev)
 
 static int summit_suspend(struct device *dev)
 {
-	int level = 0;
 	struct summit_data *panel = dev_get_drvdata(dev);
-	ssize_t err = mipi_dsi_dcs_write(panel->dsi, MIPI_DCS_SET_DISPLAY_BRIGHTNESS,
-					 &level, 1);
+
+	int err = mipi_dsi_dcs_set_display_brightness(panel->dsi, 0);
+
 	if (err < 0)
 		return err;
 	return 0;

--- a/drivers/gpu/drm/adp/panel-summit.c
+++ b/drivers/gpu/drm/adp/panel-summit.c
@@ -46,7 +46,11 @@ static int summit_probe(struct mipi_dsi_device *dsi)
 
 	mipi_dsi_set_drvdata(dsi, panel);
 	panel->dsi = dsi;
-	props.max_brightness = 255;
+
+	int ret = device_property_read_u32(dev, "max-brightness", &props.max_brightness);
+
+	if (ret)
+		props.max_brightness = 255;
 	props.type = BACKLIGHT_RAW;
 
 	panel->bl = devm_backlight_device_register(dev, dev_name(dev),


### PR DESCRIPTION
Some summit panels like the ones found on iPhone X has a max brightness of 2047 and needs 16-bit writes. This change seems to work on both A11 and M1.