### PR TITLE
Give users a chance to plug their headsets in

### DIFF
--- a/sound/soc/codecs/cs42l84.c
+++ b/sound/soc/codecs/cs42l84.c
@@ -724,7 +724,7 @@ static void cs42l84_detect_hs(struct cs42l84_private *cs42l84)
 		CS42L84_MISC_DET_CTL_PDN_MIC_LVL_DET, 0);
 
 	/* TODO: Optimize */
-	msleep(100);
+	msleep(50);
 
 	/* Connect HSBIAS in CTIA wiring */
 	/* TODO: Should likely be subject of detection */
@@ -745,7 +745,7 @@ static void cs42l84_detect_hs(struct cs42l84_private *cs42l84)
 		FIELD_PREP(CS42L84_MISC_DET_CTL_DETECT_MODE, 3));
 
 	/* TODO: Optimize */
-	msleep(100);
+	msleep(50);
 
 	regmap_read(cs42l84->regmap, CS42L84_HS_DET_STATUS2, &reg);
 	regmap_update_bits(cs42l84->regmap,

--- a/sound/soc/codecs/cs42l84.c
+++ b/sound/soc/codecs/cs42l84.c
@@ -840,6 +840,8 @@ static irqreturn_t cs42l84_irq_thread(int irq, void *data)
 				cs42l84->plug_state = CS42L84_PLUG;
 				dev_dbg(cs42l84->dev, "Plug event\n");
 
+				/* Give the user time to fully seat the plug */
+				msleep(1500);
 				cs42l84_detect_hs(cs42l84);
 
 				/*


### PR DESCRIPTION
The trigger-happy tip sense interrupt fires off headset detection too fast. Sometimes, the jack might not be fully seated before it tries to figure out what is plugged in. This leads to misdetections.

Give the user a bunch of time to fully plug in their headset/headphones, and cut some of the existing delay out to make up that time.