### PR TITLE
arm64: apple: t600x: Fix typo in ppm-ki value

### DIFF
--- a/arch/arm64/boot/dts/apple/t600x-die0.dtsi
+++ b/arch/arm64/boot/dts/apple/t600x-die0.dtsi
@@ -597,7 +597,7 @@
 		apple,perf-tgt-utilization = <85>;
 		apple,power-sample-period = <8>;
 		apple,ppm-filter-time-constant-ms = <100>;
-		apple,ppm-ki = <30>;
+		apple,ppm-ki = <30.0>;
 		apple,ppm-kp = <1.5>;
 		apple,pwr-filter-time-constant = <313>;
 		apple,pwr-integral-gain = <0.0202129>;


### PR DESCRIPTION
(please squash)