### PR TITLE
dcp: set timestamps for 120hz refresh rate

### DIFF
--- a/drivers/gpu/drm/apple/dcp-internal.h
+++ b/drivers/gpu/drm/apple/dcp-internal.h
@@ -184,6 +184,7 @@ struct apple_dcp {
 	/* Current display mode */
 	bool during_modeset;
 	bool valid_mode;
+	s64 precise_sync_rate;
 	struct dcp_set_digital_out_mode_req mode;
 
 	/* completion for active turning true */

--- a/drivers/gpu/drm/apple/iomfb_template.c
+++ b/drivers/gpu/drm/apple/iomfb_template.c
@@ -1219,6 +1219,9 @@ int DCP_FW_NAME(iomfb_modeset)(struct apple_dcp *dcp,
 		.timing_mode_id = mode->timing_mode_id
 	};
 
+	/* keep around to fake timestamps in dcp_swap_submit */
+	dcp->precise_sync_rate = mode->precise_sync_rate;
+
 	cookie = kzalloc(sizeof(*cookie), GFP_KERNEL);
 	if (!cookie) {
 		return -ENOMEM;
@@ -1406,6 +1409,16 @@ void DCP_FW_NAME(iomfb_flush)(struct apple_dcp *dcp, struct drm_crtc *crtc, stru
 		req->swap.swap_enabled |= IOMFB_SET_BACKGROUND;
 		req->swap.bg_color = 0xFF000000;
 		req->clear = 1;
+	}
+
+	if (has_surface && dcp->main_display && (dcp->precise_sync_rate >> 16) == 120) {
+		/*
+		 * Fake timstamps to get 120hz refresh rate. It looks
+		 * like the actual value does not matter, as long  as it is non zero.
+		 */
+		req->swap.ts1 = 120;
+		req->swap.ts2 = 120;
+		req->swap.ts3 = 120;
 	}
 
 	/* These fields should be set together */

--- a/drivers/gpu/drm/apple/iomfb_template.h
+++ b/drivers/gpu/drm/apple/iomfb_template.h
@@ -18,7 +18,14 @@
 struct DCP_FW_NAME(dcp_swap) {
 	u64 ts1;
 	u64 ts2;
-	u64 unk_10[6];
+
+	u64 unk_10;
+	u64 unk_18;
+	u64 ts64_unk;
+	u64 unk_28;
+	u64 ts3;
+	u64 unk_38;
+
 	u64 flags1;
 	u64 flags2;
 

--- a/drivers/gpu/drm/apple/parser.c
+++ b/drivers/gpu/drm/apple/parser.c
@@ -499,19 +499,6 @@ static int parse_mode(struct dcp_parse_ctx *handle,
 	if (is_virtual)
 		return -EINVAL;
 
-	/*
-	 * HACK:
-	 * Ignore the 120 Hz mode on j314/j316 (identified by resolution).
-	 * DCP limits normal swaps to 60 Hz anyway and the 120 Hz mode might
-	 * cause choppiness with X11.
-	 * Just downscoring it and thus making the 60 Hz mode the preferred mode
-	 * seems not enough for some user space.
-	 */
-	if (vert.precise_sync_rate >> 16 == 120 &&
-	    ((horiz.active == 3024 && vert.active == 1964) ||
-	     (horiz.active == 3456 && vert.active == 2234)))
-		return -EINVAL;
-
 	vert.active -= notch_height;
 	vert.sync_width += notch_height;
 
@@ -539,6 +526,7 @@ static int parse_mode(struct dcp_parse_ctx *handle,
 
 	out->timing_mode_id = id;
 	out->color_mode_id = best_color_mode;
+	out->precise_sync_rate = vert.precise_sync_rate;
 
 	trace_iomfb_timing_mode(handle->dcp, id, *score, horiz.active,
 				vert.active, vert.precise_sync_rate,

--- a/drivers/gpu/drm/apple/parser.h
+++ b/drivers/gpu/drm/apple/parser.h
@@ -87,6 +87,7 @@ struct dcp_display_mode {
 	struct drm_display_mode mode;
 	u32 color_mode_id;
 	u32 timing_mode_id;
+	s64 precise_sync_rate;
 	struct dcp_color_mode sdr_rgb;
 	struct dcp_color_mode sdr_444;
 	struct dcp_color_mode sdr;


### PR DESCRIPTION
After looking into the timestamps sent by macos in dcp_swap_submit, it seems to me that ts3 is strictly increasing and always set. ts1 and ts2 are set a few milliseconds before ts3 (about 4ms) and ts1 a few milliseconds after ts3 (about 16ms).

All three timestamps are in mach absolute time (i.e. 41.67ns per timestep).

This works for me on a macbook pro m1 2021 . I've verified that the display is actually outputting 120 frames per second using this script: https://github.com/oliverbestmann/120hz-demo

**Edit:**
Looks like all of that does not really matter. The DCP also accepts any non zero value in the timestamp field. This PR now sets the timestamps to `120` if a 120hz mode is selected.