### PR TITLE
power: supply: macsmc: Add M3 generation power events

### DIFF
--- a/drivers/power/supply/macsmc-power.c
+++ b/drivers/power/supply/macsmc-power.c
@@ -817,6 +817,21 @@ static int macsmc_power_event(struct notifier_block *nb, unsigned long event, vo
 		power_supply_changed(power->ac);
 
 		return NOTIFY_OK;
+	} else if ((event & 0xffff0000) == 0x71130000) {
+		u8 port_index = (event >> 8) & 0xff;
+		u8 status = event & 0xff;
+
+		if (port_index == 0xff)
+			dev_info(power->dev, "Connector event: Disconnect (status 0x%02x)\n",
+				status);
+		else
+			dev_info(power->dev, "Connector event: Port %d (status 0x%02x)\n",
+				port_index + 1, status);
+
+		power_supply_changed(power->batt);
+		power_supply_changed(power->ac);
+
+		return NOTIFY_OK;
 	} else if ((event & 0xff000000) == 0x71000000) {
 		dev_info(power->dev, "Unknown charger event 0x%lx\n", event);
 


### PR DESCRIPTION
The Apple M3 machines, and potentially M1/M2 machines with updated SMC firmware, generate a new set of SMC events starting with 0x7113 when cables are plugged or unplugged. Without this patch, the kernel logs "Unknown charger event" errors, and the power status may not update immediately.

The event structure is 0x7113[Port][Status].
Observed on M3:
- Port 0 (USB-C): 0x711300xx
- Port 1 (USB-C): 0x711301xx
- Port 2 (MagSafe): 0x711302xx
- Disconnect: 0x7113ffxx

Status 0x04 indicates a stable connection, while 0x02/0x03 appear during negotiation.

This patch handles these events and triggers a power_supply_changed notification.