### PR TITLE
cpuidle-apple: only load on machines where it is known to be needed

### DIFF
--- a/drivers/cpuidle/cpuidle-apple.c
+++ b/drivers/cpuidle/cpuidle-apple.c
@@ -6,14 +6,11 @@
  */
 
 #include <linux/init.h>
-#include <linux/bitfield.h>
 #include <linux/cpuidle.h>
 #include <linux/cpu_pm.h>
 #include <linux/platform_device.h>
 #include <linux/of.h>
 #include <asm/cpuidle.h>
-
-#define DEEP_WFI_STATE_RETENTION BIT(2) // retains base CPU registers in deep WFI
 
 enum idle_state {
 	STATE_WFI,
@@ -149,10 +146,15 @@ static int __init apple_cpuidle_init(void)
 	if (!of_machine_is_compatible("apple,arm-platform"))
 		return 0;
 
-	if (!FIELD_GET(DEEP_WFI_STATE_RETENTION, read_sysreg(aidr_el1))) {
-		pr_info("cpuidle-apple: CPU does not retain state in deep WFI\n");
+	if (!(of_machine_is_compatible("apple,t8103") ||
+	      of_machine_is_compatible("apple,t6000") ||
+	      of_machine_is_compatible("apple,t6001") ||
+	      of_machine_is_compatible("apple,t6002") ||
+	      of_machine_is_compatible("apple,t8112") ||
+	      of_machine_is_compatible("apple,t6020") ||
+	      of_machine_is_compatible("apple,t6021") ||
+	      of_machine_is_compatible("apple,t6022")))
 		return 0;
-	}
 
 	pdev = platform_device_register_simple("cpuidle-apple", -1, NULL, 0);
 	if (IS_ERR(pdev)) {


### PR DESCRIPTION
This handles M4 which no longer has the Apple specific deep WFI mode but the register-based check still reports it as if it has. Attempting to use the code on M4 causes SErrors on attempting to write the s3_5_c15_c5_0 register.