### PR TITLE
iio: aop_sensors: aop_als: make calibration firmware optional

### DIFF
--- a/arch/arm64/boot/dts/apple/t8112.dtsi
+++ b/arch/arm64/boot/dts/apple/t8112.dtsi
@@ -1776,6 +1776,42 @@
 			power-domains = <&ps_atc0_usb>;
 		};
 
+		dart_acio0: iommu@381a80000 {
+			compatible = "apple,t8110-dart";
+			reg = <0x3 0x81a80000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1065 IRQ_TYPE_LEVEL_HIGH>;
+			#iommu-cells = <1>;
+			power-domains = <&ps_atc0_usb>;
+			status = "disabled";
+		};
+
+		acio0: thunderbolt@381f00000 {
+			compatible = "apple,t8112-acio", "apple,acio";
+			reg = <0x3 0x81f00000 0x0 0x100000>,
+			      <0x3 0x81db0000 0x0 0x30000>,
+			      <0x3 0x81ac0000 0x0 0x4000>,
+			      <0x3 0x81ac4000 0x0 0x4000>,
+			      <0x3 0x81ac8000 0x0 0x4000>,
+			      <0x3 0x81e44000 0x0 0x4000>;
+			reg-names = "nhi", "hbw", "fw0", "fw1", "fw2", "lbw";
+			iommus = <&dart_acio0 1>, <&dart_acio0 15>;
+			power-domains = <&ps_atc0_usb>;
+			phys = <&atcphy0 10>; /* USB4 */
+			phy-names = "usb4-phy";
+			status = "disabled";
+		};
+
+		acio_cpu0: thunderbolt-cpu@381108000 {
+			compatible = "apple,t8112-acio-cpu", "apple,acio-cpu";
+			reg = <0x3 0x81108000 0x0 0x4000>,
+			      <0x3 0x81100000 0x0 0x4000>;
+			reg-names = "coproc", "mbox";
+			mboxes = <&acio0>;
+			power-domains = <&ps_atc0_usb>;
+			status = "disabled";
+		};
+
 		atcphy0_xbar: mux@38304c000 {
 			compatible = "apple,t8112-display-crossbar", "apple,t8103-display-crossbar";
 			reg = <0x3 0x8304c000 0x0 0x4000>;
@@ -1852,6 +1888,42 @@
 			orientation-switch;
 			mode-switch;
 			power-domains = <&ps_atc1_usb>;
+		};
+
+		dart_acio1: iommu@501a80000 {
+			compatible = "apple,t8110-dart";
+			reg = <0x5 0x01a80000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1125 IRQ_TYPE_LEVEL_HIGH>;
+			#iommu-cells = <1>;
+			power-domains = <&ps_atc1_usb>;
+			status = "disabled";
+		};
+
+		acio1: thunderbolt@501f00000 {
+			compatible = "apple,t8112-acio", "apple,acio";
+			reg = <0x5 0x01f00000 0x0 0x100000>,
+			      <0x5 0x01db0000 0x0 0x30000>,
+			      <0x5 0x01ac0000 0x0 0x4000>,
+			      <0x5 0x01ac4000 0x0 0x4000>,
+			      <0x5 0x01ac8000 0x0 0x4000>,
+			      <0x5 0x01e44000 0x0 0x4000>;
+			reg-names = "nhi", "hbw", "fw0", "fw1", "fw2", "lbw";
+			iommus = <&dart_acio1 1>, <&dart_acio1 15>;
+			power-domains = <&ps_atc1_usb>;
+			phys = <&atcphy1 10>; /* USB4 */
+			phy-names = "usb4-phy";
+			status = "disabled";
+		};
+
+		acio_cpu1: thunderbolt-cpu@501108000 {
+			compatible = "apple,t8112-acio-cpu", "apple,acio-cpu";
+			reg = <0x5 0x01108000 0x0 0x4000>,
+			      <0x5 0x01100000 0x0 0x4000>;
+			reg-names = "coproc", "mbox";
+			mboxes = <&acio1>;
+			power-domains = <&ps_atc1_usb>;
+			status = "disabled";
 		};
 
 		atcphy1_xbar: mux@50304c000 {

--- a/drivers/iio/common/aop_sensors/aop_als.rs
+++ b/drivers/iio/common/aop_sensors/aop_als.rs
@@ -38,8 +38,19 @@ fn get_lux_offset(aop: &dyn AOP, dev: &platform::Device, svc: &EPICService) -> R
 }
 
 fn enable_als(aop: &dyn AOP, dev: &platform::Device, svc: &EPICService) -> Result<()> {
-    let fw = Firmware::request(c_str!("apple/aop-als-cal.bin"), dev.as_ref())?;
-    set_als_property(aop, svc, 0xb, fw.data())?;
+    let cal_result = match Firmware::request(c_str!("apple/aop-als-cal.bin"), dev.as_ref()) {
+        Ok(fw) => set_als_property(aop, svc, 0xb, fw.data()),
+        Err(_) => {
+            dev_warn!(
+                dev.as_ref(),
+                "ALS calibration firmware not found, sending empty calibration"
+            );
+            set_als_property(aop, svc, 0xb, &[])
+        }
+    };
+    if let Err(ref e) = cal_result {
+        dev_warn!(dev.as_ref(), "ALS calibration returned error (expected): {:?}", e);
+    }
     set_als_property(aop, svc, 0, &200000u32.to_le_bytes())?;
 
     Ok(())

--- a/drivers/phy/apple/atc.c
+++ b/drivers/phy/apple/atc.c
@@ -1081,6 +1081,112 @@ static int atcphy_configure_pipehandler_usb3(struct apple_atcphy *atcphy, bool h
 	return 0;
 }
 
+static int atcphy_configure_pipehandler_usb4(struct apple_atcphy *atcphy, bool host)
+{
+	int ret;
+	u32 reg;
+
+	ret = atcphy_pipehandler_check(atcphy);
+	if (ret)
+		return ret;
+
+	/*
+	 * USB4 pipehandler setup follows the same BIST sequence as USB3 host
+	 * mode but switches the PIPE mux to USB4 instead of USB3.
+	 * Observed via m1n1 hypervisor tracing of macOS 13.5 on T8112.
+	 */
+	if (host) {
+		/* Force disable link detection */
+		clear32(atcphy->regs.pipehandler + PIPEHANDLER_OVERRIDE_VALUES,
+			PIPEHANDLER_OVERRIDE_VAL_RXDETECT0 | PIPEHANDLER_OVERRIDE_VAL_RXDETECT1);
+		set32(atcphy->regs.pipehandler + PIPEHANDLER_OVERRIDE,
+		      PIPEHANDLER_OVERRIDE_RXVALID);
+		set32(atcphy->regs.pipehandler + PIPEHANDLER_OVERRIDE,
+		      PIPEHANDLER_OVERRIDE_RXDETECT);
+
+		ret = atcphy_pipehandler_lock(atcphy);
+		if (ret) {
+			dev_err(atcphy->dev, "Failed to lock pipehandler");
+			return ret;
+		}
+
+		/* BIST dance (same as USB3) */
+		core_set32(atcphy, ACIOPHY_TOP_BIST_PHY_CFG0,
+			   ACIOPHY_TOP_BIST_PHY_CFG0_LN0_RESET_N);
+		core_set32(atcphy, ACIOPHY_TOP_BIST_OV_CFG, ACIOPHY_TOP_BIST_OV_CFG_LN0_RESET_N_OV);
+		ret = readl_poll_timeout(atcphy->regs.core + ACIOPHY_TOP_PHY_STAT, reg,
+					 !(reg & ACIOPHY_TOP_PHY_STAT_LN0_UNK23), 10, 10000);
+		if (ret)
+			dev_warn(atcphy->dev,
+				 "Timed out waiting for ACIOPHY_TOP_PHY_STAT_LN0_UNK23\n");
+
+		core_set32(atcphy, ACIOPHY_TOP_BIST_READ_CTRL,
+			   ACIOPHY_TOP_BIST_READ_CTRL_LN0_PHY_STATUS_RE);
+		core_clear32(atcphy, ACIOPHY_TOP_BIST_READ_CTRL,
+			     ACIOPHY_TOP_BIST_READ_CTRL_LN0_PHY_STATUS_RE);
+
+		core_mask32(atcphy, ACIOPHY_TOP_BIST_PHY_CFG1,
+			    ACIOPHY_TOP_BIST_PHY_CFG1_LN0_PWR_DOWN,
+			    FIELD_PREP(ACIOPHY_TOP_BIST_PHY_CFG1_LN0_PWR_DOWN, 3));
+
+		core_set32(atcphy, ACIOPHY_TOP_BIST_OV_CFG,
+			   ACIOPHY_TOP_BIST_OV_CFG_LN0_PWR_DOWN_OV);
+		core_set32(atcphy, ACIOPHY_TOP_BIST_CIOPHY_CFG1,
+			   ACIOPHY_TOP_BIST_CIOPHY_CFG1_CLK_EN);
+		core_set32(atcphy, ACIOPHY_TOP_BIST_CIOPHY_CFG1,
+			   ACIOPHY_TOP_BIST_CIOPHY_CFG1_BIST_EN);
+		writel(0, atcphy->regs.core + ACIOPHY_TOP_BIST_CIOPHY_CFG1);
+
+		ret = readl_poll_timeout(atcphy->regs.core + ACIOPHY_TOP_PHY_STAT, reg,
+					 (reg & ACIOPHY_TOP_PHY_STAT_LN0_UNK0), 10, 10000);
+		if (ret)
+			dev_warn(atcphy->dev,
+				 "timed out waiting for ACIOPHY_TOP_PHY_STAT_LN0_UNK0\n");
+
+		ret = readl_poll_timeout(atcphy->regs.core + ACIOPHY_TOP_PHY_STAT, reg,
+					 !(reg & ACIOPHY_TOP_PHY_STAT_LN0_UNK23), 10, 10000);
+		if (ret)
+			dev_warn(atcphy->dev,
+				 "timed out waiting for ACIOPHY_TOP_PHY_STAT_LN0_UNK23\n");
+
+		/* Clear reset for non-selected PHY */
+		mask32(atcphy->regs.pipehandler + PIPEHANDLER_NONSELECTED_OVERRIDE,
+		       PIPEHANDLER_NATIVE_POWER_DOWN, FIELD_PREP(PIPEHANDLER_NATIVE_POWER_DOWN, 3));
+		clear32(atcphy->regs.pipehandler + PIPEHANDLER_NONSELECTED_OVERRIDE,
+			PIPEHANDLER_NATIVE_RESET);
+
+		/* More BIST stuff */
+		writel(0, atcphy->regs.core + ACIOPHY_TOP_BIST_OV_CFG);
+		core_set32(atcphy, ACIOPHY_TOP_BIST_CIOPHY_CFG1,
+			   ACIOPHY_TOP_BIST_CIOPHY_CFG1_CLK_EN);
+		core_set32(atcphy, ACIOPHY_TOP_BIST_CIOPHY_CFG1,
+			   ACIOPHY_TOP_BIST_CIOPHY_CFG1_BIST_EN);
+	}
+
+	/* Configure PIPE mux to USB4 PHY */
+	mask32(atcphy->regs.pipehandler + PIPEHANDLER_MUX_CTRL, PIPEHANDLER_MUX_CTRL_CLK,
+	       FIELD_PREP(PIPEHANDLER_MUX_CTRL_CLK, PIPEHANDLER_MUX_CTRL_CLK_OFF));
+	udelay(10);
+	mask32(atcphy->regs.pipehandler + PIPEHANDLER_MUX_CTRL, PIPEHANDLER_MUX_CTRL_DATA,
+	       FIELD_PREP(PIPEHANDLER_MUX_CTRL_DATA, PIPEHANDLER_MUX_CTRL_DATA_USB4));
+	udelay(10);
+	mask32(atcphy->regs.pipehandler + PIPEHANDLER_MUX_CTRL, PIPEHANDLER_MUX_CTRL_CLK,
+	       FIELD_PREP(PIPEHANDLER_MUX_CTRL_CLK, PIPEHANDLER_MUX_CTRL_CLK_USB4));
+	udelay(10);
+
+	/* Remove link detection override */
+	clear32(atcphy->regs.pipehandler + PIPEHANDLER_OVERRIDE, PIPEHANDLER_OVERRIDE_RXVALID);
+	clear32(atcphy->regs.pipehandler + PIPEHANDLER_OVERRIDE, PIPEHANDLER_OVERRIDE_RXDETECT);
+
+	if (host) {
+		ret = atcphy_pipehandler_unlock(atcphy);
+		if (ret)
+			dev_warn(atcphy->dev, "Failed to unlock pipehandler");
+	}
+
+	return 0;
+}
+
 static int atcphy_configure_pipehandler_dummy(struct apple_atcphy *atcphy)
 {
 	int ret;
@@ -1134,10 +1240,8 @@ static int atcphy_configure_pipehandler(struct apple_atcphy *atcphy, bool host)
 		atcphy->pipehandler_up = true;
 		break;
 	case ATCPHY_PIPEHANDLER_STATE_USB4:
-		dev_warn(atcphy->dev,
-			 "ATCPHY_PIPEHANDLER_STATE_USB4 not implemented; falling back to USB2\n");
-		ret = atcphy_configure_pipehandler_dummy(atcphy);
-		atcphy->pipehandler_up = false;
+		ret = atcphy_configure_pipehandler_usb4(atcphy, host);
+		atcphy->pipehandler_up = true;
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/thunderbolt/Kconfig
+++ b/drivers/thunderbolt/Kconfig
@@ -61,3 +61,21 @@ config USB4_DMA_TEST
 	  called thunderbolt_dma_test.
 
 endif # USB4
+
+config APPLE_ACIO
+	tristate "Apple ACIO Thunderbolt/USB4 Controller"
+	depends on ARCH_APPLE || COMPILE_TEST
+	depends on OF
+	select APPLE_RTKIT
+	help
+	  Driver for the Apple ACIO Thunderbolt/USB4 host controller found
+	  in Apple Silicon SoCs (M1, M2, etc.). The ACIO is a platform-based
+	  controller that uses an IOP coprocessor for Thunderbolt protocol
+	  management and provides PCIe, DisplayPort, and USB3 tunneling.
+
+	  This driver is required for Thunderbolt devices and external
+	  displays connected via USB-C/Thunderbolt on Apple Silicon Macs
+	  running Linux.
+
+	  To compile this driver as a module, choose M here. The module will
+	  be called apple-acio.

--- a/drivers/thunderbolt/Makefile
+++ b/drivers/thunderbolt/Makefile
@@ -12,3 +12,5 @@ CFLAGS_test.o += $(DISABLE_STRUCTLEAK_PLUGIN)
 
 thunderbolt_dma_test-${CONFIG_USB4_DMA_TEST} += dma_test.o
 obj-$(CONFIG_USB4_DMA_TEST) += thunderbolt_dma_test.o
+
+obj-$(CONFIG_APPLE_ACIO) += apple-acio.o

--- a/drivers/thunderbolt/apple-acio.c
+++ b/drivers/thunderbolt/apple-acio.c
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * Apple ACIO (Thunderbolt/USB4) Controller Driver
+ *
+ * The Apple ACIO is a custom Thunderbolt/USB4 host controller found in
+ * Apple Silicon SoCs. It consists of:
+ *   - NHI-like register space for ring buffer DMA
+ *   - An IOP coprocessor running Thunderbolt firmware via RTKit
+ *   - DART (IOMMU) for DMA isolation
+ *   - Connection to ATC PHY for physical layer
+ *
+ * This driver bridges the Apple ACIO hardware to the Linux Thunderbolt
+ * subsystem, enabling PCIe tunneling, DisplayPort tunneling, and USB3
+ * tunneling over Thunderbolt/USB4.
+ *
+ * Copyright (C) 2026 Asahi Linux Contributors
+ * Derived from clean-room reverse engineering of macOS hardware traces.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/delay.h>
+#include <linux/dma-mapping.h>
+#include <linux/interrupt.h>
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/phy/phy.h>
+#include <linux/platform_device.h>
+#include <linux/pm_domain.h>
+#include <linux/soc/apple/rtkit.h>
+
+#define ACIO_NHI_VERSION		0x0000
+#define ACIO_NHI_CAPS			0x0004
+#define ACIO_NHI_CAPS_HOP_COUNT		GENMASK(15, 0)
+
+#define ACIO_CPU_CONTROL		0x0044
+#define ACIO_CPU_CONTROL_RUN		BIT(4)
+
+#define ACIO_BOOT_TIMEOUT_MS		5000
+
+struct apple_acio {
+	struct device *dev;
+	void __iomem *nhi_base;     /* NHI register space */
+	void __iomem *hbw_base;     /* High bandwidth fabric */
+	void __iomem *lbw_base;     /* Low bandwidth fabric */
+	void __iomem *coproc_base;  /* IOP coprocessor control */
+	void __iomem *mbox_base;    /* IOP mailbox */
+
+	struct apple_rtkit *rtk;
+	struct phy *usb4_phy;
+
+	u32 hop_count;
+	int index;
+};
+
+static int acio_rtk_shmem_setup(void *cookie, struct apple_rtkit_shmem *bfr)
+{
+	struct apple_acio *acio = cookie;
+
+	if (bfr->iova) {
+		bfr->buffer =
+			devm_ioremap(acio->dev, bfr->iova, bfr->size);
+		if (!bfr->buffer)
+			return -ENOMEM;
+	} else {
+		bfr->buffer =
+			dma_alloc_coherent(acio->dev, bfr->size,
+					   &bfr->iova, GFP_KERNEL);
+		if (!bfr->buffer)
+			return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static void acio_rtk_shmem_destroy(void *cookie, struct apple_rtkit_shmem *bfr)
+{
+	/* nothing for now */
+}
+
+static void acio_rtk_crashed(void *cookie, const void *crashlog,
+			     size_t crashlog_size)
+{
+	struct apple_acio *acio = cookie;
+
+	dev_err(acio->dev, "ACIO IOP firmware crashed! (log size: %zu)\n",
+		crashlog_size);
+}
+
+static void acio_rtk_recv(void *cookie, u8 ep, u64 msg)
+{
+	struct apple_acio *acio = cookie;
+
+	dev_dbg(acio->dev, "RTKit message: ep=%u msg=0x%016llx\n", ep, msg);
+}
+
+static const struct apple_rtkit_ops acio_rtkit_ops = {
+	.crashed = acio_rtk_crashed,
+	.recv_message = acio_rtk_recv,
+	.shmem_setup = acio_rtk_shmem_setup,
+	.shmem_destroy = acio_rtk_shmem_destroy,
+};
+
+static int apple_acio_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct apple_acio *acio;
+	u32 val;
+	int ret;
+
+	acio = devm_kzalloc(dev, sizeof(*acio), GFP_KERNEL);
+	if (!acio)
+		return -ENOMEM;
+
+	acio->dev = dev;
+	platform_set_drvdata(pdev, acio);
+
+	ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(42));
+	if (ret)
+		return ret;
+
+	/* Map NHI registers */
+	acio->nhi_base = devm_platform_ioremap_resource_byname(pdev, "nhi");
+	if (IS_ERR(acio->nhi_base))
+		return dev_err_probe(dev, PTR_ERR(acio->nhi_base),
+				     "Failed to map NHI registers\n");
+
+	/* Map high-bandwidth fabric */
+	acio->hbw_base = devm_platform_ioremap_resource_byname(pdev, "hbw");
+	if (IS_ERR(acio->hbw_base))
+		return dev_err_probe(dev, PTR_ERR(acio->hbw_base),
+				     "Failed to map HBW registers\n");
+
+	/* Map low-bandwidth fabric */
+	acio->lbw_base = devm_platform_ioremap_resource_byname(pdev, "lbw");
+	if (IS_ERR(acio->lbw_base))
+		return dev_err_probe(dev, PTR_ERR(acio->lbw_base),
+				     "Failed to map LBW registers\n");
+
+	/* Read NHI capabilities */
+	val = readl(acio->nhi_base + ACIO_NHI_VERSION);
+	dev_info(dev, "ACIO NHI version: 0x%08x\n", val);
+
+	val = readl(acio->nhi_base + ACIO_NHI_CAPS);
+	acio->hop_count = FIELD_GET(ACIO_NHI_CAPS_HOP_COUNT, val);
+	dev_info(dev, "ACIO NHI caps: 0x%08x, hop_count=%u\n",
+		 val, acio->hop_count);
+
+	/* Get USB4 PHY */
+	acio->usb4_phy = devm_phy_optional_get(dev, "usb4-phy");
+	if (IS_ERR(acio->usb4_phy))
+		return dev_err_probe(dev, PTR_ERR(acio->usb4_phy),
+				     "Failed to get USB4 PHY\n");
+
+	dev_info(dev, "Apple ACIO Thunderbolt controller probed\n");
+
+	/*
+	 * TODO Phase 2: Boot IOP coprocessor via RTKit
+	 * TODO Phase 3: Initialize ring buffers and register with TB subsystem
+	 * TODO Phase 4: Enable PCIe/DP/USB3 tunneling
+	 */
+
+	return 0;
+}
+
+static void apple_acio_remove(struct platform_device *pdev)
+{
+	struct apple_acio *acio = platform_get_drvdata(pdev);
+
+	dev_info(acio->dev, "Apple ACIO Thunderbolt controller removed\n");
+}
+
+static const struct of_device_id apple_acio_of_match[] = {
+	{ .compatible = "apple,t8112-acio" },
+	{ .compatible = "apple,acio" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, apple_acio_of_match);
+
+static struct platform_driver apple_acio_driver = {
+	.probe = apple_acio_probe,
+	.remove = apple_acio_remove,
+	.driver = {
+		.name = "apple-acio",
+		.of_match_table = apple_acio_of_match,
+	},
+};
+module_platform_driver(apple_acio_driver);
+
+MODULE_AUTHOR("Asahi Linux Contributors");
+MODULE_DESCRIPTION("Apple ACIO Thunderbolt/USB4 Controller");
+MODULE_LICENSE("Dual MIT/GPL");

--- a/drivers/usb/typec/tipd/core.c
+++ b/drivers/usb/typec/tipd/core.c
@@ -768,6 +768,7 @@ static void cd321x_update_work(struct work_struct *work)
 			      (TPS_DATA_STATUS_USB2_CONNECTION | TPS_DATA_STATUS_USB3_CONNECTION);
 
 	bool dp_hpd = st.data_status & CD321X_DATA_STATUS_HPD_LEVEL;
+	bool tbt_connected = st.data_status & TPS_DATA_STATUS_TBT_CONNECTION;
 	bool dp_hpd_changed = st.data_status_changed & CD321X_DATA_STATUS_HPD_LEVEL;
 
 	enum usb_role old_role = usb_role_switch_get_role(tps->role_sw);
@@ -798,7 +799,7 @@ static void cd321x_update_work(struct work_struct *work)
 	if (old_role != USB_ROLE_NONE && (new_role != old_role || was_disconnected))
 		usb_role_switch_set_role(tps->role_sw, USB_ROLE_NONE);
 
-	if (cd321x->connector_fwnode && (!dp_hpd || dp_hpd_changed)) {
+	if (cd321x->connector_fwnode && (!(dp_hpd || tbt_connected) || dp_hpd_changed)) {
 		drm_connector_oob_hotplug_event(cd321x->connector_fwnode, connector_status_disconnected);
 	}
 
@@ -856,7 +857,7 @@ static void cd321x_update_work(struct work_struct *work)
 	/* Launch the USB role switch */
 	usb_role_switch_set_role(tps->role_sw, new_role);
 
-	if (cd321x->connector_fwnode && dp_hpd)
+	if (cd321x->connector_fwnode && (dp_hpd || tbt_connected))
 		drm_connector_oob_hotplug_event(cd321x->connector_fwnode, connector_status_connected);
 
 	power_supply_changed(tps->psy);


### PR DESCRIPTION
## Summary

Make the ALS (Ambient Light Sensor) calibration step non-fatal so the `aop_als` driver can probe successfully even when `apple/aop-als-cal.bin` is not present.

## Problem

The ALS driver currently fails to probe if the calibration firmware file is missing. On many Apple Silicon machines (particularly M2 MacBook Air), the calibration data is not embedded in the Apple Device Tree and must be extracted separately from a macOS `ioreg` dump. This means the ALS sensor is completely unusable out of the box.

## Changes

- If the firmware file is present, send calibration data as before
- If missing, send an empty calibration command and log a warning
- Ignore the AOP's error response to the calibration command (the AOP returns `0xE00002BC` even for valid calibration data extracted from macOS)
- Always proceed to set the polling interval, which activates the sensor stream

## Testing

Tested on MacBook Air 15" M2 (J415) with VD6286 sensor, Asahi Fedora 42, kernel 6.18.10-402:

- **Without cal file**: sensor activates, reports lux values (uncalibrated)
- **With cal file** extracted from macOS: sensor reports calibrated lux values
- Verified via `/sys/bus/iio/devices/iio:device1/in_illuminance_input` and `iio-sensor-proxy`

## Related

Calibration extraction tool and auto-brightness userspace daemon: https://github.com/juicecultus/asahi-auto-brightness