### PR TITLE
Pmp fixes

### DIFF
--- a/arch/arm64/boot/dts/apple/t6000.dtsi
+++ b/arch/arm64/boot/dts/apple/t6000.dtsi
@@ -23,6 +23,8 @@
 /delete-node/ &pmp_report_venc1;
 /delete-node/ &pmp_report_msr1;
 /delete-node/ &pmp_report_prores;
+/delete-node/ &pmp_report_afnc4_ioa;
+/delete-node/ &pmp_report_afnc5_ioa;
 
 &pmp {
 	apple,pio-ranges = <0x2 0x82000000 0x0 0x1000000>,

--- a/arch/arm64/boot/dts/apple/t600x-die0.dtsi
+++ b/arch/arm64/boot/dts/apple/t600x-die0.dtsi
@@ -50,14 +50,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		pmp_report_gfx: report@9 {
-			compatible = "apple,t6000-pmp-v2-report-entry";
-			reg = <0x9>;
-			label = "pmp-gfx";
-			#power-domain-cells = <0>;
-			power-domains = <&ps_gfx>;
-		};
-
 		pmp_report_ane_sys: report@a {
 			compatible = "apple,t6000-pmp-v2-report-entry";
 			reg = <0xa>;
@@ -90,6 +82,7 @@
 			label = "pmp-dispext0";
 			#power-domain-cells = <0>;
 			power-domains = <&ps_dispext0_cpu0>;
+			apple,always-on;
 		};
 
 		pmp_report_dispext1: report@e {
@@ -143,6 +136,22 @@
 			#power-domain-cells = <0>;
 			power-domains = <&ps_scodec>;
 			status = "disabled";
+		};
+
+		pmp_report_afnc4_ioa: report@1d {
+			compatible = "apple,t6000-pmp-v2-report-entry";
+			reg = <0x1d>;
+			label = "pmp-afnc4-ioa";
+			#power-domain-cells = <0>;
+			apple,always-on;
+		};
+
+		pmp_report_afnc5_ioa: report@1e {
+			compatible = "apple,t6000-pmp-v2-report-entry";
+			reg = <0x1e>;
+			label = "pmp-afnc5-ioa";
+			#power-domain-cells = <0>;
+			apple,always-on;
 		};
 
 		pmp_report_dispext2: report@20 {

--- a/arch/arm64/boot/dts/apple/t600x-pmgr.dtsi
+++ b/arch/arm64/boot/dts/apple/t600x-pmgr.dtsi
@@ -426,6 +426,7 @@
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = DIE_LABEL(pmp);
+		apple,always-on;
 	};
 #endif
 
@@ -435,6 +436,7 @@
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = DIE_LABEL(pms_sram);
+		apple,always-on;
 	};
 
 	DIE_NODE(ps_apcie_st_sys): power-controller@2e8 {

--- a/arch/arm64/boot/dts/apple/t6020.dtsi
+++ b/arch/arm64/boot/dts/apple/t6020.dtsi
@@ -23,6 +23,8 @@
 /delete-node/ &pmp_report_venc1;
 /delete-node/ &pmp_report_msr1;
 /delete-node/ &pmp_report_prores;
+/delete-node/ &pmp_report_afnc4_ioa;
+/delete-node/ &pmp_report_afnc5_ioa;
 
 &pmp {
 	apple,pio-ranges = <0x2 0x80000000 0x0 0x1000000>,

--- a/arch/arm64/boot/dts/apple/t602x-die0.dtsi
+++ b/arch/arm64/boot/dts/apple/t602x-die0.dtsi
@@ -154,6 +154,24 @@
 			status = "disabled";
 		};
 
+		pmp_report_afnc4_ioa: report@1d {
+			compatible = "apple,t6020-pmp-v2-report-entry",
+				"apple,t6000-pmp-v2-report-entry";
+			reg = <0x1d>;
+			label = "pmp-afnc4-ioa";
+			#power-domain-cells = <0>;
+			apple,always-on;
+		};
+
+		pmp_report_afnc5_ioa: report@1e {
+			compatible = "apple,t6020-pmp-v2-report-entry",
+				"apple,t6000-pmp-v2-report-entry";
+			reg = <0x1e>;
+			label = "pmp-afnc5-ioa";
+			#power-domain-cells = <0>;
+			apple,always-on;
+		};
+
 		pmp_report_dispext2: report@1f {
 			compatible = "apple,t6020-pmp-v2-report-entry",
 				"apple,t6000-pmp-v2-report-entry";

--- a/drivers/pmdomain/apple/pmp-report.c
+++ b/drivers/pmdomain/apple/pmp-report.c
@@ -157,8 +157,11 @@ static int apple_pmp_report_entry_probe(struct platform_device *pdev)
 	if (ret < 0)
 		return dev_err_probe(dev, ret, "missing label property\n");
 
-	if (of_property_read_bool(node, "apple,always-on"))
+	if (of_property_read_bool(node, "apple,always-on")) {
 		ent->genpd.flags |= GENPD_FLAG_ACTIVE_WAKEUP;
+		apple_pmp_report_set_state(&ent->genpd, true);
+	}
+
 	ent->genpd.name = name;
 	ent->genpd.power_on = apple_pmp_report_entry_power_on;
 	ent->genpd.power_off = apple_pmp_report_entry_power_off;

--- a/drivers/soc/apple/pmp.rs
+++ b/drivers/soc/apple/pmp.rs
@@ -187,7 +187,12 @@ impl PmpData {
         let n_entries = node.property_count_elem::<u64>(prop_name)? / 2;
         let ranges = node
             .property_read_array_vec::<u64>(prop_name, n_entries * 2)?
-            .required_by(&self.dev)?;
+            .optional();
+        let ranges = if let Some(r) = ranges {
+            r
+        } else {
+            return Ok((OPC_GET_IOVA_TABLE | OPC_ACK_MASK) << OPC_SHIFT);
+        };
         let mut table = self.dev.while_bound_with(|bound_dev| {
             CoherentAllocation::alloc_coherent(bound_dev, 512, GFP_KERNEL)
         })?;


### PR DESCRIPTION
1. Add afnc{4,5} so it works on max SoCs.
2. Vanilla M2 does not need an iova table, so send a null address.
3. Mark dispext as always on. We can't re-initialize dcps yet, and without being able to do so, the hdmi port dies after a sleep cycle.
4. Somehow disabling the gpu reporting fixes sleep exit hangs on m1pro (gpu still works). No idea how, and why it hangs in the first place, only that it does.