### PR TITLE
iio: common: select RUST_FW_LOADER_ABSTRACTIONS

### DIFF
--- a/drivers/iio/common/aop_sensors/Kconfig
+++ b/drivers/iio/common/aop_sensors/Kconfig
@@ -15,8 +15,8 @@ config IIO_AOP_SENSOR_ALS
 	depends on ARCH_APPLE || COMPILE_TEST
 	depends on RUST
 	depends on SYSFS
-	depends on RUST_FW_LOADER_ABSTRACTIONS
 	select APPLE_AOP
+	select RUST_FW_LOADER_ABSTRACTIONS
 	help
 	  Module to handle the ambient light sensor attached to the AOP
 	  coprocessor on Apple laptops.


### PR DESCRIPTION
Do the same as nova-core and select RUST_FW_LOADER_ABSTRACTIONS when enabling CONFIG_IIO_AOP_SENSOR_ALS, instead of depending on it.

This will prevent 'distro kernel tooling' not using the asahi defconfig from disabling CONFIG_IIO_AOP_SENSOR_ALS because nothing else enables RUST_FW_LOADER_ABSTRACTIONS.