### PR TITLE
Fix s2idle suspend: spurious SMC wake + display resume

### DIFF
--- a/drivers/gpu/drm/apple/apple_drv.c
+++ b/drivers/gpu/drm/apple/apple_drv.c
@@ -627,9 +627,13 @@ MODULE_DEVICE_TABLE(of, of_match);
 static int apple_platform_suspend(struct device *dev)
 {
 	struct apple_drm_private *apple = dev_get_drvdata(dev);
+	int ret;
 
-	if (apple)
-		return drm_mode_config_helper_suspend(&apple->drm);
+	if (apple) {
+		ret = drm_mode_config_helper_suspend(&apple->drm);
+		if (ret)
+			dev_warn(dev, "drm suspend helper failed: %d, will hotplug on resume\n", ret);
+	}
 
 	return 0;
 }
@@ -638,8 +642,13 @@ static int apple_platform_resume(struct device *dev)
 {
 	struct apple_drm_private *apple = dev_get_drvdata(dev);
 
-	if (apple)
+	if (!apple)
+		return 0;
+
+	if (apple->drm.mode_config.suspend_state)
 		drm_mode_config_helper_resume(&apple->drm);
+	else
+		drm_kms_helper_hotplug_event(&apple->drm);
 
 	return 0;
 }

--- a/drivers/input/misc/macsmc-input.c
+++ b/drivers/input/misc/macsmc-input.c
@@ -9,6 +9,7 @@
 
 #include <linux/device.h>
 #include <linux/input.h>
+#include <linux/ktime.h>
 #include <linux/mfd/core.h>
 #include <linux/mfd/macsmc.h>
 #include <linux/module.h>
@@ -21,6 +22,10 @@
  * @input: Allocated input_dev; devres managed
  * @nb: Notifier block used for incoming events from SMC (e.g. button pressed down)
  * @wakeup_mode: Set to true when system is suspended and power button events should wake it
+ * @s2idle_ready: Set when system has fully entered s2idle noirq phase
+ * @s2idle_start: Timestamp when s2idle noirq phase began (for grace period)
+ * @lid_work: Delayed work for debouncing lid state changes
+ * @pending_lid_state: Most recent lid state waiting to be reported
  */
 struct macsmc_input {
 	struct device *dev;
@@ -28,7 +33,23 @@ struct macsmc_input {
 	struct input_dev *input;
 	struct notifier_block nb;
 	bool wakeup_mode;
+	bool s2idle_ready;
+	ktime_t s2idle_start;
+	struct delayed_work lid_work;
+	u8 pending_lid_state;
 };
+
+/*
+ * The SMC fires a spurious TouchID button event within a few ms of entering
+ * s2idle. Ignore button events within this window after s2idle entry.
+ */
+#define S2IDLE_GRACE_MS		500
+
+/*
+ * The SMC sends spurious lid open/close pairs (e.g. on DP disconnect).
+ * Only report lid state after it's been stable for this long.
+ */
+#define LID_DEBOUNCE_MS		3000
 
 #define SMC_EV_BTN 0x7201
 #define SMC_EV_LID 0x7203
@@ -46,13 +67,16 @@ static void macsmc_input_event_button(struct macsmc_input *smcin, unsigned long 
 	switch (button) {
 	case BTN_POWER:
 	case BTN_TOUCHID:
-		pm_wakeup_dev_event(smcin->dev, 0, (smcin->wakeup_mode && state));
-		/*
-		 * Suppress KEY_POWER reports when suspended to avoid powering down
-		 * immediately after waking from s2idle.
-		 * */
-		if (smcin->wakeup_mode)
+		if (smcin->wakeup_mode) {
+			if (!smcin->s2idle_ready)
+				return;
+			if (ktime_ms_delta(ktime_get(), smcin->s2idle_start) < S2IDLE_GRACE_MS)
+				return;
+			if (state)
+				pm_wakeup_dev_event(smcin->dev, 0, true);
 			return;
+		}
+		pm_wakeup_dev_event(smcin->dev, 0, false);
 
 		input_report_key(smcin->input, KEY_POWER, state);
 		input_sync(smcin->input);
@@ -79,13 +103,28 @@ static void macsmc_input_event_button(struct macsmc_input *smcin, unsigned long 
 	}
 }
 
+static void macsmc_input_lid_work(struct work_struct *work)
+{
+	struct macsmc_input *smcin = container_of(work, struct macsmc_input, lid_work.work);
+
+	input_report_switch(smcin->input, SW_LID, smcin->pending_lid_state);
+	input_sync(smcin->input);
+}
+
 static void macsmc_input_event_lid(struct macsmc_input *smcin, unsigned long event)
 {
 	u8 lid_state = !!((event >> 8) & 0xff);
 
-	pm_wakeup_dev_event(smcin->dev, 0, (smcin->wakeup_mode && !lid_state));
-	input_report_switch(smcin->input, SW_LID, lid_state);
-	input_sync(smcin->input);
+	if (smcin->wakeup_mode) {
+		if (!smcin->s2idle_ready)
+			return;
+		if (!lid_state) /* Only wake on lid open */
+			pm_wakeup_dev_event(smcin->dev, 0, true);
+		return;
+	}
+
+	smcin->pending_lid_state = lid_state;
+	mod_delayed_work(system_wq, &smcin->lid_work, msecs_to_jiffies(LID_DEBOUNCE_MS));
 }
 
 static int macsmc_input_event(struct notifier_block *nb, unsigned long event, void *data)
@@ -126,6 +165,7 @@ static int macsmc_input_probe(struct platform_device *pdev)
 	smcin->dev = &pdev->dev;
 	smcin->smc = smc;
 	platform_set_drvdata(pdev, smcin);
+	INIT_DELAYED_WORK(&smcin->lid_work, macsmc_input_lid_work);
 
 	smcin->input = devm_input_allocate_device(&pdev->dev);
 	if (!smcin->input)
@@ -180,6 +220,24 @@ static int macsmc_input_pm_prepare(struct device *dev)
 	struct macsmc_input *smcin = dev_get_drvdata(dev);
 
 	smcin->wakeup_mode = true;
+	smcin->s2idle_ready = false;
+	return 0;
+}
+
+static int macsmc_input_suspend_noirq(struct device *dev)
+{
+	struct macsmc_input *smcin = dev_get_drvdata(dev);
+
+	smcin->s2idle_ready = true;
+	smcin->s2idle_start = ktime_get();
+	return 0;
+}
+
+static int macsmc_input_resume_noirq(struct device *dev)
+{
+	struct macsmc_input *smcin = dev_get_drvdata(dev);
+
+	smcin->s2idle_ready = false;
 	return 0;
 }
 
@@ -187,11 +245,14 @@ static void macsmc_input_pm_complete(struct device *dev)
 {
 	struct macsmc_input *smcin = dev_get_drvdata(dev);
 
+	cancel_delayed_work_sync(&smcin->lid_work);
 	smcin->wakeup_mode = false;
 }
 
 static const struct dev_pm_ops macsmc_input_pm_ops = {
 	.prepare = macsmc_input_pm_prepare,
+	.suspend_noirq = macsmc_input_suspend_noirq,
+	.resume_noirq = macsmc_input_resume_noirq,
 	.complete = macsmc_input_pm_complete,
 };
 


### PR DESCRIPTION
Hey, I've been dealing with completely broken suspend on my M1 MacBook Pro for a while now and finally tracked down what's going on. There are two separate bugs that combine to make s2idle unusable.

## What's broken

**1. Instant wake from s2idle (macsmc-input)**

The SMC fires a spurious TouchID button press within ~1ms of entering the s2idle noirq phase. You can see it clearly in dmesg — the system enters suspend, immediately gets a button event, and wakes right back up. Every single time.

**2. Display never comes back (apple-drm)**

`drm_mode_config_helper_suspend()` fails with `-EINVAL` when there's a disconnected secondary DCP (pretty common if you've ever had an external display plugged in). The old code returned this error directly to the PM core, so the entire suspend just failed before even reaching s2idle.

If you work around the DRM error to let suspend proceed, the display doesn't come back on resume because `suspend_state` was never saved.

## What this fixes

**macsmc-input:**
- Added `suspend_noirq`/`resume_noirq` hooks with a `s2idle_ready` flag so button events are only processed when the system is actually in s2idle
- Added a 500ms grace period after s2idle entry — the spurious SMC event arrives within 1ms, so this filters it reliably without affecting real power button wakes
- Debounced lid events with a 3 second delay. The SMC sends false lid open/close pairs on DP disconnect, which made `HandleLidSwitch=suspend` unusable in logind. Now only stable state changes get reported.

**apple-drm:**
- Suspend no longer returns the DRM helper error to the PM core — it logs a warning and continues
- On resume, checks if `suspend_state` was actually saved. If it was, does a normal restore. If not, fires a `drm_kms_helper_hotplug_event()` so the compositor re-probes and brings the display back up.

## Testing

Tested on M1 MacBook Pro running the fairydust branch (6.18.10). Both manual `systemctl suspend` and lid-triggered suspend via `HandleLidSwitch=suspend` work reliably now. System suspends, stays suspended, wakes on power button press, and the display comes back.