### PR TITLE
fix s2idle suspend (spurious SMC wake + broken display resume)

### DIFF
--- a/drivers/gpu/drm/apple/apple_drv.c
+++ b/drivers/gpu/drm/apple/apple_drv.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only OR MIT
-/* Copyright 2021 Alyssa Rosenzweig */
+/* Copyright 2021 Alyssa Rosenzweig <alyssa@rosenzweig.io> */
 /* Based on meson driver which is
  * Copyright (C) 2016 BayLibre, SAS
  * Author: Neil Armstrong <narmstrong@baylibre.com>
@@ -109,8 +109,6 @@ static void apple_crtc_atomic_enable(struct drm_crtc *crtc,
 	if (crtc_state->active_changed && crtc_state->active) {
 		struct apple_crtc *apple_crtc = to_apple_crtc(crtc);
 		dcp_poweron(apple_crtc->dcp);
-		/* Force the CTM to be set on first swap */
-		crtc_state->color_mgmt_changed = true;
 	}
 
 	if (crtc_state->active)
@@ -439,8 +437,9 @@ static int apple_drm_init_dcp(struct device *dev)
 		 * (successfully). Ignoring it should not do any harm now.
 		 * Needs to reevaluated when adding dcpext support.
 		 */
-		if (ret)
+		if (ret) {
 			dev_warn(dev, "DCP[%d] not ready: %d\n", i, ret);
+		}
 	}
 	/* HACK: Wait for dcp* to settle before a modeset */
 	msleep(100);
@@ -627,9 +626,13 @@ MODULE_DEVICE_TABLE(of, of_match);
 static int apple_platform_suspend(struct device *dev)
 {
 	struct apple_drm_private *apple = dev_get_drvdata(dev);
+	int ret;
 
-	if (apple)
-		return drm_mode_config_helper_suspend(&apple->drm);
+	if (apple) {
+		ret = drm_mode_config_helper_suspend(&apple->drm);
+		if (ret)
+			dev_warn(dev, "drm suspend helper failed: %d, will hotplug on resume\n", ret);
+	}
 
 	return 0;
 }
@@ -638,8 +641,13 @@ static int apple_platform_resume(struct device *dev)
 {
 	struct apple_drm_private *apple = dev_get_drvdata(dev);
 
-	if (apple)
+	if (!apple)
+		return 0;
+
+	if (apple->drm.mode_config.suspend_state)
 		drm_mode_config_helper_resume(&apple->drm);
+	else
+		drm_kms_helper_hotplug_event(&apple->drm);
 
 	return 0;
 }
@@ -690,6 +698,6 @@ static void __exit appledrm_unregister(void)
 module_init(appledrm_register);
 module_exit(appledrm_unregister);
 
-MODULE_AUTHOR("Asahi Linux contributors");
+MODULE_AUTHOR("Alyssa Rosenzweig <alyssa@rosenzweig.io>");
 MODULE_DESCRIPTION(DRIVER_DESC);
 MODULE_LICENSE("Dual MIT/GPL");

--- a/drivers/input/misc/macsmc-input.c
+++ b/drivers/input/misc/macsmc-input.c
@@ -9,6 +9,7 @@
 
 #include <linux/device.h>
 #include <linux/input.h>
+#include <linux/ktime.h>
 #include <linux/mfd/core.h>
 #include <linux/mfd/macsmc.h>
 #include <linux/module.h>
@@ -28,7 +29,16 @@ struct macsmc_input {
 	struct input_dev *input;
 	struct notifier_block nb;
 	bool wakeup_mode;
+	bool s2idle_ready;
+	ktime_t s2idle_start;
+	struct delayed_work lid_work;
+	u8 pending_lid_state;
 };
+
+/* Ignore spurious SMC button events within this window after s2idle entry */
+#define S2IDLE_GRACE_MS		500
+/* Lid state must be stable for this long before reporting to userspace */
+#define LID_DEBOUNCE_MS		3000
 
 #define SMC_EV_BTN 0x7201
 #define SMC_EV_LID 0x7203
@@ -46,13 +56,22 @@ static void macsmc_input_event_button(struct macsmc_input *smcin, unsigned long 
 	switch (button) {
 	case BTN_POWER:
 	case BTN_TOUCHID:
-		pm_wakeup_dev_event(smcin->dev, 0, (smcin->wakeup_mode && state));
-		/*
-		 * Suppress KEY_POWER reports when suspended to avoid powering down
-		 * immediately after waking from s2idle.
-		 * */
-		if (smcin->wakeup_mode)
+		if (smcin->wakeup_mode) {
+			if (!smcin->s2idle_ready) {
+				dev_info(smcin->dev, "SUPPRESSED btn (not in s2idle yet)\n");
+				return;
+			}
+			if (ktime_ms_delta(ktime_get(), smcin->s2idle_start) < S2IDLE_GRACE_MS) {
+				dev_info(smcin->dev, "SUPPRESSED btn (spurious, %lldms after s2idle)\n",
+					 ktime_ms_delta(ktime_get(), smcin->s2idle_start));
+				return;
+			}
+			dev_info(smcin->dev, "ALLOWING btn (s2idle_ready, state=%d)\n", state);
+			if (state)
+				pm_wakeup_dev_event(smcin->dev, 0, true);
 			return;
+		}
+		pm_wakeup_dev_event(smcin->dev, 0, false);
 
 		input_report_key(smcin->input, KEY_POWER, state);
 		input_sync(smcin->input);
@@ -79,13 +98,28 @@ static void macsmc_input_event_button(struct macsmc_input *smcin, unsigned long 
 	}
 }
 
+static void macsmc_input_lid_work(struct work_struct *work)
+{
+	struct macsmc_input *smcin = container_of(work, struct macsmc_input, lid_work.work);
+
+	input_report_switch(smcin->input, SW_LID, smcin->pending_lid_state);
+	input_sync(smcin->input);
+}
+
 static void macsmc_input_event_lid(struct macsmc_input *smcin, unsigned long event)
 {
 	u8 lid_state = !!((event >> 8) & 0xff);
 
-	pm_wakeup_dev_event(smcin->dev, 0, (smcin->wakeup_mode && !lid_state));
-	input_report_switch(smcin->input, SW_LID, lid_state);
-	input_sync(smcin->input);
+	if (smcin->wakeup_mode) {
+		if (!smcin->s2idle_ready)
+			return;
+		if (!lid_state) /* Only wake on lid open */
+			pm_wakeup_dev_event(smcin->dev, 0, true);
+		return;
+	}
+
+	smcin->pending_lid_state = lid_state;
+	mod_delayed_work(system_wq, &smcin->lid_work, msecs_to_jiffies(LID_DEBOUNCE_MS));
 }
 
 static int macsmc_input_event(struct notifier_block *nb, unsigned long event, void *data)
@@ -126,6 +160,7 @@ static int macsmc_input_probe(struct platform_device *pdev)
 	smcin->dev = &pdev->dev;
 	smcin->smc = smc;
 	platform_set_drvdata(pdev, smcin);
+	INIT_DELAYED_WORK(&smcin->lid_work, macsmc_input_lid_work);
 
 	smcin->input = devm_input_allocate_device(&pdev->dev);
 	if (!smcin->input)
@@ -180,6 +215,27 @@ static int macsmc_input_pm_prepare(struct device *dev)
 	struct macsmc_input *smcin = dev_get_drvdata(dev);
 
 	smcin->wakeup_mode = true;
+	smcin->s2idle_ready = false;
+	dev_info(dev, "WAKEUP_MODE ON, s2idle_ready=false\n");
+	return 0;
+}
+
+static int macsmc_input_suspend_noirq(struct device *dev)
+{
+	struct macsmc_input *smcin = dev_get_drvdata(dev);
+
+	smcin->s2idle_ready = true;
+	smcin->s2idle_start = ktime_get();
+	dev_info(dev, "suspend_noirq: s2idle_ready=true\n");
+	return 0;
+}
+
+static int macsmc_input_resume_noirq(struct device *dev)
+{
+	struct macsmc_input *smcin = dev_get_drvdata(dev);
+
+	smcin->s2idle_ready = false;
+	dev_info(dev, "resume_noirq: s2idle_ready=false\n");
 	return 0;
 }
 
@@ -187,11 +243,14 @@ static void macsmc_input_pm_complete(struct device *dev)
 {
 	struct macsmc_input *smcin = dev_get_drvdata(dev);
 
+	cancel_delayed_work_sync(&smcin->lid_work);
 	smcin->wakeup_mode = false;
 }
 
 static const struct dev_pm_ops macsmc_input_pm_ops = {
 	.prepare = macsmc_input_pm_prepare,
+	.suspend_noirq = macsmc_input_suspend_noirq,
+	.resume_noirq = macsmc_input_resume_noirq,
 	.complete = macsmc_input_pm_complete,
 };
 


### PR DESCRIPTION
Suspend has been completely broken on my M1 MacBook Air - two separate issues that stack on top of each other.

The first problem is in `macsmc-input`. The SMC fires a spurious TouchID button press within about 1ms of entering the s2idle noirq phase, which the driver treats as a wake event. So the system enters suspend and immediately wakes back up, every time. You can see it in dmesg pretty clearly.

To fix this I added suspend_noirq/resume_noirq hooks with an `s2idle_ready` flag and a 500ms grace period after s2idle entry. The spurious event comes in within 1ms so it gets filtered out, but a real power button press (which would come seconds or minutes later) still works fine.

I also added a 3 second debounce on lid events while I was in there. The SMC sends false lid open/close pairs on DP disconnect which makes `HandleLidSwitch=suspend` in logind completely unusable - it just randomly thinks the lid is closed when it isn't. With the debounce, only stable state changes actually get reported to userspace.

The second problem is in apple-drm. `drm_mode_config_helper_suspend()` fails with `-EINVAL` when a secondary DCP is disconnected, and the old code returned that error straight to the PM core. So suspend just fails before it even gets to s2idle. If you work around that to let suspend continue, the display won't come back on resume because suspend_state never got saved.

The fix: don't let the DRM error block suspend (just log a warning), and on resume check if suspend_state exists. If it does, normal resume path. If not, fire a hotplug event so the DCP and compositor can sort the display out themselves.

Tested on M1 MacBook Air, fairydust branch (6.18.10). Manual systemctl suspend and lid-triggered suspend both work now.

(I also added Alyssa Rosenzweig's email to the beginning of the file)