### PR TITLE
arm64: dts: apple: Add PCIe nodes for t6031

### DIFF
--- a/arch/arm64/boot/dts/apple/t6030-j514s.dts
+++ b/arch/arm64/boot/dts/apple/t6030-j514s.dts
@@ -20,3 +20,11 @@
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j514s.bin";
 };
+
+&wifi0 {
+	brcm,board-type = "apple,texa";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,texa";
+};

--- a/arch/arm64/boot/dts/apple/t6030-j516s.dts
+++ b/arch/arm64/boot/dts/apple/t6030-j516s.dts
@@ -20,3 +20,11 @@
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j516s.bin";
 };
+
+&wifi0 {
+	brcm,board-type = "apple,jura";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,jura";
+};

--- a/arch/arm64/boot/dts/apple/t6031-j514c.dts
+++ b/arch/arm64/boot/dts/apple/t6031-j514c.dts
@@ -20,3 +20,11 @@
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j514c.bin";
 };
+
+&wifi0 {
+	brcm,board-type = "apple,texa";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,texa";
+};

--- a/arch/arm64/boot/dts/apple/t6031-j516c.dts
+++ b/arch/arm64/boot/dts/apple/t6031-j516c.dts
@@ -20,3 +20,11 @@
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j516c.bin";
 };
+
+&wifi0 {
+	brcm,board-type = "apple,jura";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,jura";
+};

--- a/arch/arm64/boot/dts/apple/t6034-j514m.dts
+++ b/arch/arm64/boot/dts/apple/t6034-j514m.dts
@@ -20,3 +20,11 @@
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j514m.bin";
 };
+
+&wifi0 {
+	brcm,board-type = "apple,texa";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,texa";
+};

--- a/arch/arm64/boot/dts/apple/t6034-j516m.dts
+++ b/arch/arm64/boot/dts/apple/t6034-j516m.dts
@@ -20,3 +20,11 @@
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j516m.bin";
 };
+
+&wifi0 {
+	brcm,board-type = "apple,jura";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,jura";
+};

--- a/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
+++ b/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
@@ -116,6 +116,7 @@
 &port00 {
 	/* WLAN */
 	bus-range = <1 1>;
+	pwren-gpios = <&smc_gpio 19 GPIO_ACTIVE_HIGH>;
 	wifi0: wifi@0,0 {
 		compatible = "pci14e4,4433";
 		reg = <0x10000 0x0 0x0 0x0 0x0>;
@@ -135,6 +136,7 @@
 &port01 {
 	/* SD card reader */
 	bus-range = <2 2>;
+	pwren-gpios = <&smc_gpio 25 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 	sdhci0: mmc@0,0 {
 		compatible = "pci17a0,9755";

--- a/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
+++ b/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
@@ -21,7 +21,9 @@
 	chassis-type = "laptop";
 
 	aliases {
+		bluetooth0 = &bluetooth0;
 		serial0 = &serial0;
+		wifi0 = &wifi0;
 	};
 
 	chosen {
@@ -102,4 +104,46 @@
 
 	tp_accel {
 	};
+};
+
+/* PCIe devices */
+
+/*
+ * Force the bus number assignments so that we can declare some of the
+ * on-board devices and properties that are populated by the bootloader
+ * (such as MAC addresses).
+ */
+&port00 {
+	/* WLAN */
+	bus-range = <1 1>;
+	wifi0: wifi@0,0 {
+		compatible = "pci14e4,4433";
+		reg = <0x10000 0x0 0x0 0x0 0x0>;
+		/* To be filled by the loader */
+		local-mac-address = [00 10 18 00 00 10];
+		apple,antenna-sku = "XX";
+	};
+
+	bluetooth0: bluetooth@0,1 {
+		compatible = "pci14e4,5f71";
+		reg = <0x10100 0x0 0x0 0x0 0x0>;
+		/* To be filled by the loader */
+		local-bd-address = [00 00 00 00 00 00];
+	};
+};
+
+&port01 {
+	/* SD card reader */
+	bus-range = <2 2>;
+	status = "okay";
+	sdhci0: mmc@0,0 {
+		compatible = "pci17a0,9755";
+		reg = <0x20000 0x0 0x0 0x0 0x0>;
+		cd-inverted;
+		wp-inverted;
+	};
+};
+
+&pcie0_dart_1 {
+	status = "okay";
 };


### PR DESCRIPTION

    Adds the pcie0 node on die0 of all M3 Max / Ultra chips (t6031/t6032/t6034), as
    well as pwren-gpios for WiFi and Bluetooth of the MacBook Pros using these
    chips.
    
    The M3 Ultra t6032, which is part of this family of devices, theoretically
    has a pcie1 node, but it's not directly used for anything except nvme, which
    is already present in the device tree.
    
    The pwren- and reset-gpios have been sourced from Apple's device trees, and are
    confirmed on the MacBook Pro 14", 14-cores, 2023 (j514m).
    
    Once the t6030 pcie0 node is added, we can move the WiFi / Bluetooth parts into
    t603x-j514-j516.dtsi, as the pwren-gpios are the same across all
    M3 / M3 Pro / M3 Max MacBook Pros.
