### PR TITLE
wifi/bluetooth: fix Broadcom BCM4387 D3 suspend timeout and race

### DIFF
--- a/drivers/bluetooth/hci_bcm4377.c
+++ b/drivers/bluetooth/hci_bcm4377.c
@@ -1832,8 +1832,15 @@ static int bcm4377_boot(struct bcm4377_data *bcm4377)
 	int ret = 0;
 	u32 bootstage, rti_status;
 
+	int retries = 50;
 	bootstage = ioread32(bcm4377->bar2 + bcm4377->hw->bar2_offset + BCM4377_BAR2_BOOTSTAGE);
 	rti_status = ioread32(bcm4377->bar2 + bcm4377->hw->bar2_offset + BCM4377_BAR2_RTI_STATUS);
+	while ((bootstage != 0 || rti_status != 0) && retries > 0) {
+		msleep(10);
+		bootstage = ioread32(bcm4377->bar2 + bcm4377->hw->bar2_offset + BCM4377_BAR2_BOOTSTAGE);
+		rti_status = ioread32(bcm4377->bar2 + bcm4377->hw->bar2_offset + BCM4377_BAR2_RTI_STATUS);
+		retries--;
+	}
 
 	if (bootstage != 0) {
 		dev_err(&bcm4377->pdev->dev, "bootstage is %d and not 0\n",
@@ -2421,11 +2428,26 @@ static int bcm4377_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 static int bcm4377_suspend(struct pci_dev *pdev, pm_message_t state)
 {
 	struct bcm4377_data *bcm4377 = pci_get_drvdata(pdev);
+	struct pci_dev *wifi_pdev;
 	int ret;
 
 	ret = hci_suspend_dev(bcm4377->hdev);
 	if (ret)
 		return ret;
+
+	wifi_pdev = pci_get_slot(pdev->bus, PCI_DEVFN(PCI_SLOT(pdev->devfn), 0));
+	if (wifi_pdev) {
+		int retries = 500;
+		while (wifi_pdev->current_state < PCI_D3hot && retries > 0) {
+			msleep(10);
+			retries--;
+		}
+		if (retries == 0) {
+			dev_warn(&pdev->dev, "WiFi sibling function did not enter D3 in time (state=%d)\n",
+				 wifi_pdev->current_state);
+		}
+		pci_dev_put(wifi_pdev);
+	}
 
 	iowrite32(BCM4377_BAR0_SLEEP_CONTROL_QUIESCE,
 		  bcm4377->bar0 + BCM4377_BAR0_SLEEP_CONTROL);

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
@@ -328,7 +328,7 @@ static const struct brcmf_firmware_mapping brcmf_pcie_fwnames[] = {
 #define BRCMF_H2D_HOST_D0_INFORM_IN_USE		0x00000008
 #define BRCMF_H2D_HOST_D0_INFORM		0x00000010
 
-#define BRCMF_PCIE_MBDATA_TIMEOUT		msecs_to_jiffies(2000)
+#define BRCMF_PCIE_MBDATA_TIMEOUT		msecs_to_jiffies(5000)
 
 #define BRCMF_PCIE_CFGREG_STATUS_CMD		0x4
 #define BRCMF_PCIE_CFGREG_PM_CSR		0x4C
@@ -2997,6 +2997,7 @@ static int brcmf_pcie_pm_enter_D3(struct device *dev)
 {
 	struct brcmf_pciedev_info *devinfo;
 	struct brcmf_bus *bus;
+	int ret;
 
 	brcmf_dbg(PCIE, "Enter\n");
 
@@ -3007,7 +3008,12 @@ static int brcmf_pcie_pm_enter_D3(struct device *dev)
 	brcmf_bus_change_state(bus, BRCMF_BUS_DOWN);
 
 	devinfo->mbdata_completed = false;
-	brcmf_pcie_send_mb_data(devinfo, BRCMF_H2D_HOST_D3_INFORM);
+	ret = brcmf_pcie_send_mb_data(devinfo, BRCMF_H2D_HOST_D3_INFORM);
+	if (ret) {
+		brcmf_err(bus, "Failed to send H2D D3 inform mailbox data (%d)\n", ret);
+		brcmf_bus_change_state(bus, BRCMF_BUS_UP);
+		return ret;
+	}
 
 	wait_event_timeout(devinfo->mbdata_resp_wait, devinfo->mbdata_completed,
 			   BRCMF_PCIE_MBDATA_TIMEOUT);


### PR DESCRIPTION
The Broadcom BCM4387 PCIe device consistently fails to enter the D3 power state during system suspend, causing timeouts/hangs upon resume.

Fixes:
- WiFi Driver: Increased BRCMF_PCIE_MBDATA_TIMEOUT to 5 seconds and added return code validation to brcmf_pcie_pm_enter_D3.
- Bluetooth Driver: Added retry loops on bootstage and rti_status checks in bcm4377_boot to allow slower wakeups.
- Coordinated Quiesce: Modified bcm4377_suspend to locate the sibling WiFi PCI function (function 0) and wait until it transitions to PCI_D3hot or PCI_D3cold before writing BCM4377_BAR0_SLEEP_CONTROL_QUIESCE.

Solves issue #507. This fix was created by AI. This has only been progression-tested on system level.