### PR TITLE
cpuidle-apple: load on M3 / Pro / Max / Ultra

### DIFF
--- a/drivers/cpuidle/cpuidle-apple.c
+++ b/drivers/cpuidle/cpuidle-apple.c
@@ -148,12 +148,17 @@ static int __init apple_cpuidle_init(void)
 
 	if (!(of_machine_is_compatible("apple,t8103") ||
 	      of_machine_is_compatible("apple,t8112") ||
+	      of_machine_is_compatible("apple,t8122") ||
 	      of_machine_is_compatible("apple,t6000") ||
 	      of_machine_is_compatible("apple,t6001") ||
 	      of_machine_is_compatible("apple,t6002") ||
 	      of_machine_is_compatible("apple,t6020") ||
 	      of_machine_is_compatible("apple,t6021") ||
-	      of_machine_is_compatible("apple,t6022")))
+	      of_machine_is_compatible("apple,t6022") ||
+	      of_machine_is_compatible("apple,t6030") ||
+	      of_machine_is_compatible("apple,t6031") ||
+	      of_machine_is_compatible("apple,t6032") ||
+	      of_machine_is_compatible("apple,t6034")))
 		return 0;
 
 	pdev = platform_device_register_simple("cpuidle-apple", -1, NULL, 0);


### PR DESCRIPTION
This enables the Apple-specific deep WFI mode on more machines which support it.