### PR TITLE
power: supply: macsmc: Prevent shutdowns with macOS 27 firmware

### DIFF
--- a/drivers/power/supply/macsmc-power.c
+++ b/drivers/power/supply/macsmc-power.c
@@ -45,6 +45,7 @@ struct macsmc_power {
 	bool has_ch0i;
 	bool has_ch0c;
 	bool has_chte;
+	bool bcf0_1byte;
 
 	u8 num_cells;
 	int nominal_voltage_mv;
@@ -416,6 +417,18 @@ static int macsmc_battery_get_date(const char *s, int *out)
 	return 0;
 }
 
+static int macsmc_battery_read_bcf0(struct macsmc_power *power, u32 *val)
+{
+	u8 tval;
+	int ret;
+
+	if (!power->bcf0_1byte)
+		return apple_smc_read_u32(power->smc, SMC_KEY(BCF0), val);
+	ret = apple_smc_read_u8(power->smc, SMC_KEY(BCF0), &tval);
+	*val = tval;
+	return ret;
+}
+
 static int macsmc_battery_get_capacity_level(struct macsmc_power *power)
 {
 	bool flag;
@@ -423,7 +436,7 @@ static int macsmc_battery_get_capacity_level(struct macsmc_power *power)
 	int ret;
 
 	/* Check for emergency shutdown condition */
-	if (apple_smc_read_u32(power->smc, SMC_KEY(BCF0), &val) >= 0 && val)
+	if (macsmc_battery_read_bcf0(power, &val) >= 0 && val)
 		return POWER_SUPPLY_CAPACITY_LEVEL_CRITICAL;
 
 	/* Check AC status for whether we could boot in this state */
@@ -824,7 +837,7 @@ static void macsmc_power_critical_work(struct work_struct *wrk)
 		return;
 
 	/* Check for battery empty condition */
-	ret = apple_smc_read_u32(power->smc, SMC_KEY(BCF0), &bcf0);
+	ret = macsmc_battery_read_bcf0(power, &bcf0);
 	if (ret < 0) {
 		dev_err(power->dev,
 				"Emergency notification: Failed to read battery status\n");
@@ -915,6 +928,7 @@ static int macsmc_power_probe(struct platform_device *pdev)
 {
 	struct apple_smc *smc = dev_get_drvdata(pdev->dev.parent);
 	struct power_supply_config psy_cfg = {};
+	struct apple_smc_key_info info;
 	struct macsmc_power *power;
 	bool flag;
 	u8 val8;
@@ -949,6 +963,21 @@ static int macsmc_power_probe(struct platform_device *pdev)
 
 	if (apple_smc_read_u8(power->smc, SMC_KEY(CH0I), &val8) >= 0)
 		power->has_ch0i = true;
+
+	ret = apple_smc_get_key_info(power->smc, SMC_KEY(BCF0), &info);
+	/* failing to read this can cause spurious emergency shutdowns, so refuse to probe */
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to determine BCF0 key size\n");
+		return ret;
+	}
+	if (info.size == 1)
+		power->bcf0_1byte = true;
+	else if (info.size == 4)
+		power->bcf0_1byte = false;
+	else {
+		dev_err(&pdev->dev, "Unexpected BCF0 key size %d\n", info.size);
+		return -EIO;
+	}
 
 	/* Turn off the "optimized battery charging" flags, in case macOS left them on */
 	if (power->has_chte)
@@ -989,7 +1018,7 @@ static int macsmc_power_probe(struct platform_device *pdev)
 	power->nominal_voltage_mv = MACSMC_NOMINAL_CELL_VOLTAGE_MV * power->num_cells;
 
 	/* Doing one read of this flag enables critical shutdown notifications */
-	apple_smc_read_u32(power->smc, SMC_KEY(BCF0), &val32);
+	macsmc_battery_read_bcf0(power, &val32);
 
 	psy_cfg.drv_data = power;
 	power->batt = devm_power_supply_register(&pdev->dev, &power->batt_desc, &psy_cfg);


### PR DESCRIPTION
The SMC firmware included in macOS 27 changed the size of BCF0 key from 4 to 1 bytes. A failure to read it was interpreted as battery being at a critical level and caused undesired emergency shutdowns in certain cases