### PR TITLE
drm/apple: advertise GAMMA_LUT and approximate it via the colour matrix

### DIFF
--- a/drivers/gpu/drm/apple/apple_drv.c
+++ b/drivers/gpu/drm/apple/apple_drv.c
@@ -313,7 +313,15 @@ static int apple_probe_per_dcp(struct device *dev,
 		return ret;
 
 	drm_crtc_helper_add(&crtc->base, &apple_crtc_helper_funcs);
-	drm_crtc_enable_color_mgmt(&crtc->base, 0, true, 0);
+	/*
+	 * The DCP firmware exposes no arbitrary gamma-LUT IPC, only a 3x3
+	 * colour matrix (iomfb_set_matrix / "A422"). Advertise a 256-entry
+	 * GAMMA_LUT anyway so userspace features gated on gamma support
+	 * (notably GNOME Night Light) become available; the swap builder folds
+	 * the ramp into the matrix diagonal. Non-linear curves (e.g. ICC VCGT
+	 * calibration) collapse to their linear per-channel gain.
+	 */
+	drm_crtc_enable_color_mgmt(&crtc->base, 0, true, 256);
 
 	enc = drmm_simple_encoder_alloc(drm, struct apple_encoder, base,
 					DRM_MODE_ENCODER_TMDS);

--- a/drivers/gpu/drm/apple/iomfb_template.c
+++ b/drivers/gpu/drm/apple/iomfb_template.c
@@ -12,6 +12,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/iommu.h>
 #include <linux/kref.h>
+#include <linux/math64.h>
 #include <linux/module.h>
 #include <linux/of_device.h>
 #include <linux/pm_runtime.h>
@@ -1422,6 +1423,40 @@ void DCP_FW_NAME(iomfb_flush)(struct apple_dcp *dcp, struct drm_crtc *crtc, stru
 			memcpy(mat.matrix, ctm->matrix, sizeof(mat.matrix));
 		} else {
 			mat.matrix[0] = mat.matrix[4] = mat.matrix[8] = 1LLU << 32;
+		}
+
+		/*
+		 * The firmware has no gamma-LUT IPC, so approximate a per-channel
+		 * gamma ramp as a diagonal gain folded into the colour matrix.
+		 * The DRM pipeline is out = GAMMA(CTM(in)), so the combined
+		 * transform is diag(g) * CTM, i.e. scale matrix row i by g[i].
+		 * Exact for the linear ramps used by Night Light; a non-linear
+		 * curve is reduced to its endpoint gain (matrix[] and CTM are
+		 * S31.32, and all Night Light coefficients are positive, so the
+		 * sign bit is preserved and the magnitude scaled).
+		 */
+		if (crtc_state->gamma_lut) {
+			struct drm_color_lut *lut = crtc_state->gamma_lut->data;
+			u32 n = crtc_state->gamma_lut->length / sizeof(*lut);
+
+			if (n) {
+				u64 g[3] = {
+					((u64)lut[n - 1].red   << 32) / 0xffff,
+					((u64)lut[n - 1].green << 32) / 0xffff,
+					((u64)lut[n - 1].blue  << 32) / 0xffff,
+				};
+				int row, col;
+
+				for (row = 0; row < 3; row++) {
+					for (col = 0; col < 3; col++) {
+						u64 *e = &mat.matrix[row * 3 + col];
+						u64 sign = *e & (1ULL << 63);
+
+						*e = sign | mul_u64_u64_shr(*e & ~(1ULL << 63),
+									    g[row], 32);
+					}
+				}
+			}
 		}
 
 		iomfb_set_matrix(dcp, false, &mat, do_swap, NULL);


### PR DESCRIPTION
## What

Make GNOME Night Light (and any per-channel gamma adjustment) work on Apple Silicon laptops driven by apple-dcp.

## Why

The DCP firmware has a 3x3 colour matrix IPC (\`iomfb_set_matrix\` / \`A422\`) but no arbitrary gamma LUT, so the driver advertises CTM only — \`drm_crtc_enable_color_mgmt(crtc, 0, true, 0)\`. GNOME gates Night Light *availability* on gamma support, so the toggle is greyed out and does nothing on machines like the MacBook Air M2 (whose internal panel exposes no EDID and thus has no other colour path).

## How

- Advertise a 256-entry \`GAMMA_LUT\`.
- In the swap builder, fold the ramp's per-channel endpoint gain into the diagonal of the matrix already sent via \`set_matrix\` (\`out = diag(g) · CTM\`).

Exact for the linear per-channel ramps Night Light and brightness use. A non-linear transfer curve (ICC VCGT calibration) is reduced to its linear gain — the firmware can't apply an arbitrary transfer function, so this is the best achievable without a new IPC. The tradeoff is documented in the code comment.

## Testing

MacBook Air M2 (t8112), kernel 7.0 (Ubuntu Asahi). With this patch plus an sRGB colord profile assigned to the panel, GNOME Night Light warms the internal display (verified via /sys/kernel/debug/dri state and on-screen).

End-to-end reproduction + scripts: https://github.com/BuenGenio/asahi-m2-nightlight

Happy to resend via the asahi-devel / dri-devel mailing list if that's the preferred flow.