### PR TITLE
drm/asahi: Clean up deferred BOs when dropping a VM

### DIFF
--- a/drivers/gpu/drm/asahi/file.rs
+++ b/drivers/gpu/drm/asahi/file.rs
@@ -87,6 +87,8 @@ impl Drop for Vm {
         {
             pr_err!("Vm::Drop: vm.unmap_range() failed\n");
         }
+
+        self.vm.bo_deferred_cleanup();
     }
 }
 


### PR DESCRIPTION
Since DRM GPUVM immediate mode was enabled, unmapping a GPU VA can defer
`drm_gpuvm_bo` destruction until `drm_gpuvm_bo_deferred_cleanup()` is called.
The GEM bind and unbind paths drain that list, but `Vm::drop()` unmaps the
remaining user ranges without doing so.

Drain the deferred list after both teardown unmaps. Otherwise a deferred
`drm_gpuvm_bo` retains the imported GEM and dma-buf after its DRM file is
closed, leaving its backing pages pinned.

Fixes: 2aeee2dd4a79 ("drm/asahi: Switch gpuvm to DRM_GPUVM_IMMEDIATE_MODE")

Validation:

- Pre-patch: A GPU-accelerated VM would consume all system RAM while playing
  games until the system crashed.
- Post-patch: The GPU-accelerated VM no longer consumes all host memory. Memory
  is returned, and host crashes no longer occur.
