### PR TITLE
Audio: Drop SDZ dummy regulator and use shared gpio

### DIFF
--- a/arch/arm64/Kconfig.platforms
+++ b/arch/arm64/Kconfig.platforms
@@ -37,6 +37,7 @@ config ARCH_APPLE
 	bool "Apple Silicon SoC family"
 	select APPLE_AIC
 	select APPLE_PMGR_PWRSTATE if PM
+	select HAVE_SHARED_GPIOS
 	help
 	  This enables support for Apple's in-house ARM SoC family, such
 	  as the Apple M1.

--- a/arch/arm64/boot/dts/apple/t600x-j314-j316.dtsi
+++ b/arch/arm64/boot/dts/apple/t600x-j314-j316.dtsi
@@ -247,24 +247,13 @@
 	};
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	status = "okay";
 
 	speaker_left_tweet: codec@3a {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3a>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 179 IRQ_TYPE_LEVEL_LOW>;
@@ -275,7 +264,7 @@
 	speaker_left_woof1: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 1";
 		interrupts-extended = <&pinctrl_ap 179 IRQ_TYPE_LEVEL_LOW>;
@@ -286,7 +275,7 @@
 	speaker_left_woof2: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 2";
 		interrupts-extended = <&pinctrl_ap 179 IRQ_TYPE_LEVEL_LOW>;
@@ -314,7 +303,7 @@
 	speaker_right_tweet: codec@3d {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3d>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 179 IRQ_TYPE_LEVEL_LOW>;
@@ -325,7 +314,7 @@
 	speaker_right_woof1: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 1";
 		interrupts-extended = <&pinctrl_ap 179 IRQ_TYPE_LEVEL_LOW>;
@@ -336,7 +325,7 @@
 	speaker_right_woof2: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 178 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 2";
 		interrupts-extended = <&pinctrl_ap 179 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t602x-j414-j416.dtsi
+++ b/arch/arm64/boot/dts/apple/t602x-j414-j416.dtsi
@@ -55,32 +55,33 @@
 	interrupts = <44 IRQ_TYPE_LEVEL_LOW>;
 };
 
-/* Redefine GPIO for SDZ */
-&speaker_sdz {
-	gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
-};
-
 &speaker_left_tweet {
+	shutdown-gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 58 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_left_woof1 {
+	shutdown-gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 58 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_left_woof2 {
+	shutdown-gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 58 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_tweet {
+	shutdown-gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 58 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_woof1 {
+	shutdown-gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 58 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_woof2 {
+	shutdown-gpios = <&pinctrl_ap 57 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 58 IRQ_TYPE_LEVEL_LOW>;
 };
 

--- a/arch/arm64/boot/dts/apple/t6030-j514s.dts
+++ b/arch/arm64/boot/dts/apple/t6030-j514s.dts
@@ -33,31 +33,33 @@
 	brcm,board-type = "apple,texa";
 };
 
-&speaker_sdz {
-	gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
-};
-
 &speaker_left_tweet {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_left_woof1 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_left_woof2 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_tweet {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_woof1 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_woof2 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 

--- a/arch/arm64/boot/dts/apple/t6030-j516s.dts
+++ b/arch/arm64/boot/dts/apple/t6030-j516s.dts
@@ -33,31 +33,33 @@
 	brcm,board-type = "apple,jura";
 };
 
-&speaker_sdz {
-	gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
-};
-
 &speaker_left_tweet {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_left_woof1 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_left_woof2 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_tweet {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_woof1 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 
 &speaker_right_woof2 {
+	shutdown-gpios = <&pinctrl_ap 171 GPIO_ACTIVE_HIGH>;
 	interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
 };
 

--- a/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
+++ b/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
@@ -108,23 +108,13 @@
 	};
 };
 
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	status = "okay";
 
 	speaker_left_tweet: codec@3a {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3a>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
@@ -135,7 +125,7 @@
 	speaker_left_woof1: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 1";
 		interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
@@ -146,7 +136,7 @@
 	speaker_left_woof2: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 2";
 		interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
@@ -174,7 +164,7 @@
 	speaker_right_tweet: codec@3d {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3d>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
@@ -185,7 +175,7 @@
 	speaker_right_woof1: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 1";
 		interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;
@@ -196,7 +186,7 @@
 	speaker_right_woof2: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 28 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 2";
 		interrupts-extended = <&pinctrl_ap 29 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8103-j293.dts
+++ b/arch/arm64/boot/dts/apple/t8103-j293.dts
@@ -95,22 +95,11 @@
 	};
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-tas5770-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "tas5770-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left_rear: codec@31 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x31>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Rear";
 		interrupts-extended = <&pinctrl_ap 182 IRQ_TYPE_LEVEL_LOW>;
@@ -122,7 +111,7 @@
 	speaker_left_front: codec@32 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x32>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Front";
 		interrupts-extended = <&pinctrl_ap 182 IRQ_TYPE_LEVEL_LOW>;
@@ -151,7 +140,7 @@
 	speaker_right_rear: codec@34 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x34>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Rear";
 		interrupts-extended = <&pinctrl_ap 182 IRQ_TYPE_LEVEL_LOW>;
@@ -163,7 +152,7 @@
 	speaker_right_front: codec@35 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x35>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Front";
 		interrupts-extended = <&pinctrl_ap 182 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8103-j313.dts
+++ b/arch/arm64/boot/dts/apple/t8103-j313.dts
@@ -94,22 +94,11 @@
 	};
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-tas5770-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "tas5770-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left: codec@31 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x31>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left";
 		interrupts-extended = <&pinctrl_ap 182 IRQ_TYPE_LEVEL_LOW>;
@@ -122,7 +111,7 @@
 	speaker_right: codec@34 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x34>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right";
 		interrupts-extended = <&pinctrl_ap 182 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8112-j413.dts
+++ b/arch/arm64/boot/dts/apple/t8112-j413.dts
@@ -101,22 +101,11 @@
 	};
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left_woof: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -127,7 +116,7 @@
 	speaker_left_tweet: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -140,7 +129,7 @@
 	speaker_right_woof: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -151,7 +140,7 @@
 	speaker_right_tweet: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8112-j415.dts
+++ b/arch/arm64/boot/dts/apple/t8112-j415.dts
@@ -101,22 +101,11 @@
 	};
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left_woof1: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 1";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -127,7 +116,7 @@
 	speaker_left_tweet: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -138,7 +127,7 @@
 	speaker_left_woof2: codec@3a {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3a>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 2";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -151,7 +140,7 @@
 	speaker_right_woof1: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 1";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -162,7 +151,7 @@
 	speaker_right_tweet: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -173,7 +162,7 @@
 	speaker_right_woof2: codec@3d {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3d>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 2";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8112-j493.dts
+++ b/arch/arm64/boot/dts/apple/t8112-j493.dts
@@ -137,22 +137,11 @@
 	label = "USB-C Left-front";
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left_rear: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Rear";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -163,7 +152,7 @@
 	speaker_left_front: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Front";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -176,7 +165,7 @@
 	speaker_right_rear: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Rear";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;
@@ -187,7 +176,7 @@
 	speaker_right_front: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 88 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Front";
 		interrupts-extended = <&pinctrl_ap 11 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8122-j504.dts
+++ b/arch/arm64/boot/dts/apple/t8122-j504.dts
@@ -132,23 +132,13 @@
 	apple,machine-kind = "MacBook Pro";
 };
 
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	status = "okay";
 
 	speaker_left_tweet: codec@3a {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3a>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -159,7 +149,7 @@
 	speaker_left_woof1: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 1";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -170,7 +160,7 @@
 	speaker_left_woof2: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer 2";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -194,7 +184,7 @@
 	speaker_right_tweet: codec@3d {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3d>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -205,7 +195,7 @@
 	speaker_right_woof1: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 1";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -216,7 +206,7 @@
 	speaker_right_woof2: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer 2";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8122-j613.dts
+++ b/arch/arm64/boot/dts/apple/t8122-j613.dts
@@ -60,22 +60,11 @@
 	apple,machine-kind = "MacBook Air";
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left_woof: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -86,7 +75,7 @@
 	speaker_left_tweet: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -99,7 +88,7 @@
 	speaker_right_woof: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -110,7 +99,7 @@
 	speaker_right_tweet: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;

--- a/arch/arm64/boot/dts/apple/t8122-j615.dts
+++ b/arch/arm64/boot/dts/apple/t8122-j615.dts
@@ -60,22 +60,11 @@
 	brcm,board-type = "apple,tuzla";
 };
 
-/* Virtual regulator representing the shared shutdown GPIO */
-/ {
-	speaker_sdz: fixed-regulator-sn012776-sdz {
-		compatible = "regulator-fixed";
-		regulator-name = "sn012776-sdz";
-		startup-delay-us = <5000>;
-		gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
 &i2c1 {
 	speaker_left_woof: codec@38 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x38>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Woofer";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -86,7 +75,7 @@
 	speaker_left_tweet: codec@39 {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x39>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Left Tweeter";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -99,7 +88,7 @@
 	speaker_right_woof: codec@3b {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3b>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Woofer";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;
@@ -110,7 +99,7 @@
 	speaker_right_tweet: codec@3c {
 		compatible = "ti,sn012776", "ti,tas2764";
 		reg = <0x3c>;
-		SDZ-supply = <&speaker_sdz>;
+		shutdown-gpios = <&pinctrl_ap 13 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
 		sound-name-prefix = "Right Tweeter";
 		interrupts-extended = <&pinctrl_ap 12 IRQ_TYPE_LEVEL_LOW>;

--- a/sound/soc/codecs/tas2764.c
+++ b/sound/soc/codecs/tas2764.c
@@ -975,7 +975,7 @@ static int tas2764_parse_dt(struct device *dev, struct tas2764_priv *tas2764)
 		}
 	}
 
-	tas2764->sdz_gpio = devm_gpiod_get_optional(dev, "shutdown", GPIOD_OUT_HIGH);
+	tas2764->sdz_gpio = devm_gpiod_get_optional(dev, "shutdown", GPIOD_OUT_LOW);
 	if (IS_ERR(tas2764->sdz_gpio)) {
 		if (PTR_ERR(tas2764->sdz_gpio) == -EPROBE_DEFER)
 			return -EPROBE_DEFER;

--- a/sound/soc/codecs/tas2764.c
+++ b/sound/soc/codecs/tas2764.c
@@ -12,7 +12,6 @@
 #include <linux/pm.h>
 #include <linux/i2c.h>
 #include <linux/gpio/consumer.h>
-#include <linux/regulator/consumer.h>
 #include <linux/regmap.h>
 #include <linux/of.h>
 #include <linux/of_device.h>
@@ -34,7 +33,6 @@ struct tas2764_priv {
 	struct snd_soc_component *component;
 	struct gpio_desc *reset_gpio;
 	struct gpio_desc *sdz_gpio;
-	struct regulator *sdz_reg;
 	struct regmap *regmap;
 	struct device *dev;
 	int irq;
@@ -158,8 +156,6 @@ static int tas2764_codec_suspend(struct snd_soc_component *component)
 	if (tas2764->sdz_gpio)
 		gpiod_set_value_cansleep(tas2764->sdz_gpio, 0);
 
-	regulator_disable(tas2764->sdz_reg);
-
 	regcache_cache_only(tas2764->regmap, true);
 	regcache_mark_dirty(tas2764->regmap);
 
@@ -172,13 +168,6 @@ static int tas2764_codec_resume(struct snd_soc_component *component)
 {
 	struct tas2764_priv *tas2764 = snd_soc_component_get_drvdata(component);
 	int ret;
-
-	ret = regulator_enable(tas2764->sdz_reg);
-
-	if (ret) {
-		dev_err(tas2764->dev, "Failed to enable regulator\n");
-		return ret;
-	}
 
 	if (tas2764->sdz_gpio) {
 		gpiod_set_value_cansleep(tas2764->sdz_gpio, 1);
@@ -770,12 +759,6 @@ static int tas2764_codec_probe(struct snd_soc_component *component)
 
 	tas2764->component = component;
 
-	ret = regulator_enable(tas2764->sdz_reg);
-	if (ret != 0) {
-		dev_err(tas2764->dev, "Failed to enable regulator: %d\n", ret);
-		return ret;
-	}
-
 	if (tas2764->sdz_gpio) {
 		gpiod_set_value_cansleep(tas2764->sdz_gpio, 1);
 	}
@@ -852,13 +835,6 @@ static int tas2764_codec_probe(struct snd_soc_component *component)
 	return 0;
 }
 
-static void tas2764_codec_remove(struct snd_soc_component *component)
-{
-	struct tas2764_priv *tas2764 = snd_soc_component_get_drvdata(component);
-
-	regulator_disable(tas2764->sdz_reg);
-}
-
 static DECLARE_TLV_DB_SCALE(tas2764_digital_tlv, 1100, 50, 0);
 static DECLARE_TLV_DB_SCALE(tas2764_playback_volume, -10050, 50, 1);
 
@@ -890,7 +866,6 @@ static const struct snd_kcontrol_new tas2764_snd_controls[] = {
 
 static const struct snd_soc_component_driver soc_component_driver_tas2764 = {
 	.probe			= tas2764_codec_probe,
-	.remove			= tas2764_codec_remove,
 	.suspend		= tas2764_codec_suspend,
 	.resume			= tas2764_codec_resume,
 	.controls		= tas2764_snd_controls,
@@ -960,11 +935,6 @@ static const struct regmap_config tas2764_i2c_regmap = {
 static int tas2764_parse_dt(struct device *dev, struct tas2764_priv *tas2764)
 {
 	int ret = 0;
-
-	tas2764->sdz_reg = devm_regulator_get(dev, "SDZ");
-	if (IS_ERR(tas2764->sdz_reg))
-		return dev_err_probe(dev, PTR_ERR(tas2764->sdz_reg),
-				"Failed to get SDZ supply\n");
 
 	tas2764->reset_gpio = devm_gpiod_get_optional(tas2764->dev, "reset",
 						      GPIOD_OUT_HIGH);

--- a/sound/soc/codecs/tas2770.c
+++ b/sound/soc/codecs/tas2770.c
@@ -16,7 +16,6 @@
 #include <linux/pm.h>
 #include <linux/i2c.h>
 #include <linux/gpio/consumer.h>
-#include <linux/regulator/consumer.h>
 #include <linux/firmware.h>
 #include <linux/regmap.h>
 #include <linux/of.h>
@@ -80,8 +79,6 @@ static int tas2770_codec_suspend(struct snd_soc_component *component)
 	if (tas2770->sdz_gpio)
 		gpiod_set_value_cansleep(tas2770->sdz_gpio, 0);
 
-	regulator_disable(tas2770->sdz_reg);
-
 	regcache_cache_only(tas2770->regmap, true);
 	regcache_mark_dirty(tas2770->regmap);
 
@@ -94,13 +91,6 @@ static int tas2770_codec_resume(struct snd_soc_component *component)
 {
 	struct tas2770_priv *tas2770 = snd_soc_component_get_drvdata(component);
 	int ret;
-
-	ret = regulator_enable(tas2770->sdz_reg);
-
-	if (ret) {
-		dev_err(tas2770->dev, "Failed to enable regulator\n");
-		return ret;
-	}
 
 	if (tas2770->sdz_gpio)
 		gpiod_set_value_cansleep(tas2770->sdz_gpio, 1);
@@ -725,12 +715,6 @@ static int tas2770_codec_probe(struct snd_soc_component *component)
 
 	tas2770->component = component;
 
-	ret = regulator_enable(tas2770->sdz_reg);
-	if (ret != 0) {
-		dev_err(tas2770->dev, "Failed to enable regulator: %d\n", ret);
-		return ret;
-	}
-
 	if (tas2770->sdz_gpio) {
 		gpiod_set_value_cansleep(tas2770->sdz_gpio, 1);
 	}
@@ -758,13 +742,6 @@ static int tas2770_codec_probe(struct snd_soc_component *component)
 	return 0;
 }
 
-static void tas2770_codec_remove(struct snd_soc_component *component)
-{
-	struct tas2770_priv *tas2770 = snd_soc_component_get_drvdata(component);
-
-	regulator_disable(tas2770->sdz_reg);
-}
-
 static DECLARE_TLV_DB_SCALE(tas2770_digital_tlv, 1100, 50, 0);
 static DECLARE_TLV_DB_SCALE(tas2770_playback_volume, -10050, 50, 0);
 
@@ -777,7 +754,6 @@ static const struct snd_kcontrol_new tas2770_snd_controls[] = {
 
 static const struct snd_soc_component_driver soc_component_driver_tas2770 = {
 	.probe			= tas2770_codec_probe,
-	.remove			= tas2770_codec_remove,
 	.suspend		= tas2770_codec_suspend,
 	.resume			= tas2770_codec_resume,
 	.controls		= tas2770_snd_controls,
@@ -906,11 +882,6 @@ static int tas2770_parse_dt(struct device *dev, struct tas2770_priv *tas2770)
 				      &tas2770->pdm_slot);
 	if (rc)
 		tas2770->pdm_slot = -1;
-
-	tas2770->sdz_reg = devm_regulator_get(dev, "SDZ");
-	if (IS_ERR(tas2770->sdz_reg))
-		return dev_err_probe(dev, PTR_ERR(tas2770->sdz_reg),
-				     "Failed to get SDZ supply\n");
 
 	tas2770->sdz_gpio = devm_gpiod_get_optional(dev, "shutdown", GPIOD_OUT_LOW);
 	if (IS_ERR(tas2770->sdz_gpio)) {

--- a/sound/soc/codecs/tas2770.c
+++ b/sound/soc/codecs/tas2770.c
@@ -912,7 +912,7 @@ static int tas2770_parse_dt(struct device *dev, struct tas2770_priv *tas2770)
 		return dev_err_probe(dev, PTR_ERR(tas2770->sdz_reg),
 				     "Failed to get SDZ supply\n");
 
-	tas2770->sdz_gpio = devm_gpiod_get_optional(dev, "shutdown", GPIOD_OUT_HIGH);
+	tas2770->sdz_gpio = devm_gpiod_get_optional(dev, "shutdown", GPIOD_OUT_LOW);
 	if (IS_ERR(tas2770->sdz_gpio)) {
 		if (PTR_ERR(tas2770->sdz_gpio) == -EPROBE_DEFER)
 			return -EPROBE_DEFER;

--- a/sound/soc/codecs/tas2770.h
+++ b/sound/soc/codecs/tas2770.h
@@ -150,7 +150,6 @@ struct tas2770_priv {
 	struct snd_soc_component *component;
 	struct gpio_desc *reset_gpio;
 	struct gpio_desc *sdz_gpio;
-	struct regulator *sdz_reg;
 	struct regmap *regmap;
 	struct device *dev;
 	int v_sense_slot;


### PR DESCRIPTION
Shared GPIO works upstream now. Drop the regulator API abuse and move to the upstream shared GPIO infrastructure.

Top 3 commits can be sent on the mailing list once this has been tested with M3 devices. The commits dropping the dummy regulator use can probably just be dropped along with the commits introducing it, and the DT changes will need to be carried until audio is fully upstreamed.