### PR TITLE
arm64: dts: apple: Add Apple T6040 (M4 Pro) SoC and MacBook Pro 14-inch (J614s) skeleton

### DIFF
--- a/arch/arm64/boot/dts/apple/Makefile
+++ b/arch/arm64/boot/dts/apple/Makefile
@@ -100,6 +100,7 @@ dtb-$(CONFIG_ARCH_APPLE) += t6031-j516c.dtb
 dtb-$(CONFIG_ARCH_APPLE) += t6032-j575d.dtb
 dtb-$(CONFIG_ARCH_APPLE) += t6034-j514m.dtb
 dtb-$(CONFIG_ARCH_APPLE) += t6034-j516m.dtb
+dtb-$(CONFIG_ARCH_APPLE) += t6040-j614s.dtb
 dtb-$(CONFIG_ARCH_APPLE) += t8112-j413.dtb
 dtb-$(CONFIG_ARCH_APPLE) += t8112-j415.dtb
 dtb-$(CONFIG_ARCH_APPLE) += t8112-j473.dtb

--- a/arch/arm64/boot/dts/apple/t6040-j614s.dts
+++ b/arch/arm64/boot/dts/apple/t6040-j614s.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * Apple MacBook Pro (14-inch, M4 Pro, Late 2024)
+ *
+ * target-type: J614s
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+/dts-v1/;
+
+#include "t6040.dtsi"
+
+/ {
+	compatible = "apple,j614s", "apple,t6040", "apple,arm-platform";
+	model = "Apple MacBook Pro (14-inch, M4 Pro, Late 2024)";
+
+	aliases {
+		serial0 = &serial0;
+	};
+
+	chosen {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		stdout-path = "serial0";
+
+		framebuffer0: framebuffer@0 {
+			compatible = "apple,simple-framebuffer", "simple-framebuffer";
+			reg = <0 0 0 0>; /* To be filled by loader */
+			/* Format properties will be added by loader */
+			status = "disabled";
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+		/* To be filled by loader */
+	};
+
+	memory@800000000 {
+		device_type = "memory";
+		reg = <0x8 0 0x2 0>; /* To be filled by loader */
+	};
+};
+
+&serial0 {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/apple/t6040.dtsi
+++ b/arch/arm64/boot/dts/apple/t6040.dtsi
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * Apple T6040 "M4 Pro" SoC
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+#include <dt-bindings/interrupt-controller/apple-aic.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/apple.h>
+
+/ {
+	compatible = "apple,t6040", "apple,arm-platform";
+
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cpus {
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		cpu-map {
+			cluster0 {
+				core0 {
+					cpu = <&cpu_e0>;
+				};
+				core1 {
+					cpu = <&cpu_e1>;
+				};
+				core2 {
+					cpu = <&cpu_e2>;
+				};
+				core3 {
+					cpu = <&cpu_e3>;
+				};
+			};
+
+			cluster1 {
+				core0 {
+					cpu = <&cpu_p0>;
+				};
+				core1 {
+					cpu = <&cpu_p1>;
+				};
+				core2 {
+					cpu = <&cpu_p2>;
+				};
+				core3 {
+					cpu = <&cpu_p3>;
+				};
+			};
+
+			cluster2 {
+				core0 {
+					cpu = <&cpu_p4>;
+				};
+				core1 {
+					cpu = <&cpu_p5>;
+				};
+				core2 {
+					cpu = <&cpu_p6>;
+				};
+				core3 {
+					cpu = <&cpu_p7>;
+				};
+			};
+		};
+
+		cpu_e0: cpu@0 {
+			compatible = "apple,brava-e";
+			device_type = "cpu";
+			reg = <0x0 0x0>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_0>;
+		};
+
+		cpu_e1: cpu@1 {
+			compatible = "apple,brava-e";
+			device_type = "cpu";
+			reg = <0x0 0x1>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_0>;
+		};
+
+		cpu_e2: cpu@2 {
+			compatible = "apple,brava-e";
+			device_type = "cpu";
+			reg = <0x0 0x2>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_0>;
+		};
+
+		cpu_e3: cpu@3 {
+			compatible = "apple,brava-e";
+			device_type = "cpu";
+			reg = <0x0 0x3>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_0>;
+		};
+
+		cpu_p0: cpu@10100 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10100>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_1>;
+		};
+
+		cpu_p1: cpu@10101 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10101>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_1>;
+		};
+
+		cpu_p2: cpu@10102 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10102>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_1>;
+		};
+
+		cpu_p3: cpu@10103 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10103>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_1>;
+		};
+
+		cpu_p4: cpu@10200 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10200>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_2>;
+		};
+
+		cpu_p5: cpu@10201 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10201>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_2>;
+		};
+
+		cpu_p6: cpu@10202 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10202>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_2>;
+		};
+
+		cpu_p7: cpu@10203 {
+			compatible = "apple,brava-p";
+			device_type = "cpu";
+			reg = <0x0 0x10203>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0 0>;
+			next-level-cache = <&l2_cache_2>;
+		};
+
+		l2_cache_0: l2-cache-0 {
+			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+		};
+
+		l2_cache_1: l2-cache-1 {
+			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+		};
+
+		l2_cache_2: l2-cache-2 {
+			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+		};
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&aic>;
+		interrupt-names = "phys", "virt", "hyp-phys", "hyp-virt";
+		interrupts = <AIC_FIQ AIC_TMR_GUEST_PHYS IRQ_TYPE_LEVEL_HIGH>,
+		             <AIC_FIQ AIC_TMR_GUEST_VIRT IRQ_TYPE_LEVEL_HIGH>,
+		             <AIC_FIQ AIC_TMR_HV_PHYS IRQ_TYPE_LEVEL_HIGH>,
+		             <AIC_FIQ AIC_TMR_HV_VIRT IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	clkref: clock-ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <24000000>;
+		clock-output-names = "clkref";
+	};
+
+	soc: soc {
+		compatible = "simple-bus";
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		ranges;
+		nonposted-mmio;
+
+		pmgr: power-management@502800000 {
+			compatible = "apple,t6040-pmgr", "apple,t8132-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x5 0x02800000 0 0x14000>;
+			/* child nodes to be added after dumping the full PMGR state via m1n1 */
+		};
+
+		aic: interrupt-controller@502400000 {
+			compatible = "apple,t6040-aic3", "apple,t8122-aic3";
+			#interrupt-cells = <3>;
+			interrupt-controller;
+			reg = <0x00000005 0x02400000 0x00000000 0x1cc000>,
+			      <0x00000005 0x02440000 0x00000000 0x4000>;
+			reg-names = "core", "event";
+
+			affinities {
+				e-core-pmu-affinity {
+					apple,fiq-index = <AIC_CPU_PMU_E>;
+					cpus = <&cpu_e0 &cpu_e1 &cpu_e2 &cpu_e3>;
+				};
+
+				p-core-pmu-affinity {
+					apple,fiq-index = <AIC_CPU_PMU_P>;
+					cpus = <&cpu_p0 &cpu_p1 &cpu_p2 &cpu_p3 &cpu_p4 &cpu_p5 &cpu_p6 &cpu_p7>;
+				};
+			};
+		};
+
+		wdt: watchdog@50836c000 {
+			compatible = "apple,t6040-wdt", "apple,t8103-wdt";
+			reg = <0x5 0x0836c000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 827 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		pinctrl_nub: pinctrl@5081e4000 {
+			compatible = "apple,t6040-pinctrl", "apple,t8103-pinctrl";
+			reg = <0x5 0x081e4000 0x0 0x4000>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl_nub 0 0 32>;
+			apple,npins = <32>;
+
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 819 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 820 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 821 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 822 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 823 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 824 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 825 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		pinctrl_smc: pinctrl@50c824000 {
+			compatible = "apple,t6040-pinctrl", "apple,t8103-pinctrl";
+			reg = <0x5 0x0c824000 0x0 0x4000>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl_smc 0 0 18>;
+			apple,npins = <18>;
+
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 985 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 986 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 987 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 988 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 989 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 990 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 991 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		pinctrl_aop: pinctrl@510824000 {
+			compatible = "apple,t6040-pinctrl", "apple,t8103-pinctrl";
+			reg = <0x5 0x10824000 0x0 0x4000>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl_aop 0 0 57>;
+			apple,npins = <57>;
+
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 700 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 701 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 702 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 703 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 704 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 705 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 706 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		pinctrl_ap: pinctrl@51c000000 {
+			compatible = "apple,t6040-pinctrl", "apple,t8103-pinctrl";
+			reg = <0x5 0x1c000000 0x0 0x100000>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl_ap 0 0 224>;
+			apple,npins = <224>;
+
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 478 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 479 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 480 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 481 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 482 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 483 IRQ_TYPE_LEVEL_HIGH>,
+			             <AIC_IRQ 484 IRQ_TYPE_LEVEL_HIGH>;
+
+			/* Pinmux assignments not yet known for T6040; to be filled
+			 * in after bring-up experiments.
+			 */
+		};
+
+		i2c0: i2c@429014000 {
+			compatible = "apple,t6040-i2c", "apple,t8103-i2c";
+			reg = <0x4 0x29014000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1576 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@429018000 {
+			compatible = "apple,t6040-i2c", "apple,t8103-i2c";
+			reg = <0x4 0x29018000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1577 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@42901c000 {
+			compatible = "apple,t6040-i2c", "apple,t8103-i2c";
+			reg = <0x4 0x2901c000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1578 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		i2c3: i2c@429020000 {
+			compatible = "apple,t6040-i2c", "apple,t8103-i2c";
+			reg = <0x4 0x29020000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1579 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		i2c4: i2c@429028000 {
+			compatible = "apple,t6040-i2c", "apple,t8103-i2c";
+			reg = <0x4 0x29028000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1581 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		i2c5: i2c@429030000 {
+			compatible = "apple,t6040-i2c", "apple,t8103-i2c";
+			reg = <0x4 0x29030000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1583 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		spi0: spi@429108000 {
+			compatible = "apple,t6040-spi", "apple,t8103-spi";
+			reg = <0x4 0x29108000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1569 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		spi1: spi@429110000 {
+			compatible = "apple,t6040-spi", "apple,t8103-spi";
+			reg = <0x4 0x29110000 0x0 0x4000>;
+			clocks = <&clkref>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1571 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "disabled";
+		};
+
+		fpwm0: pwm@429040000 {
+			compatible = "apple,t6040-fpwm", "apple,s5l-fpwm";
+			reg = <0x4 0x29040000 0x0 0x4000>;
+			clocks = <&clkref>;
+			#pwm-cells = <2>;
+			status = "disabled";
+		};
+
+		serial0: serial@429200000 {
+			compatible = "apple,s5l-uart";
+			reg = <0x4 0x29200000 0x0 0x1000>;
+			reg-io-width = <4>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 1559 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clkref>, <&clkref>;
+			clock-names = "uart", "clk_uart_baud0";
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
## arm64: dts: apple: Add Apple T6040 (M4 Pro) SoC + MacBook Pro 14" (J614s) skeleton

RFC / early bring-up contribution. This adds the first devicetrees for the
T6040 SoC ("Brava Chop", M4 Pro) and one machine using it.

### Data provenance

Every register address and interrupt number comes from a dump of the
IODeviceTree registry plane (`ioreg -lw0 -p IODeviceTree`) of a live
MacBook Pro (14-inch, M4 Pro, Late 2024):

| Block | Node | Physical base | IRQ(s) |
|---|---|---|---|
| AIC v3 | aic | 0x502400000 (+0x40000 event) | — |
| PMGR | pmgr | 0x502800000 | 306/307/467/309 |
| UART0 | uart0 | 0x429200000 | 1559 |
| WDT | wdt | 0x50836c000 | 827 |
| pinctrl ap/nub/smc/aop | gpio0/nub-gpio0/smc-gpio0/aop-gpio0 | 0x51c000000 / 0x5081e4000 / 0x50c824000 / 0x510824000 | 478–484 / 819–825 / 985–991 / 700–706 |
| I²C ×6 | i2c1..i2c8 | 0x429014000…0x429030000 | 1576–1583 |
| SPI ×2 | spi2/spi4 | 0x429108000 / 0x429110000 | 1569 / 1571 |

The UART address independently matches m1n1's `EARLY_UART_BASE` for T6040.

### Explicitly unverified / TODO before this can leave RFC

1. **CPU `reg` values**: MPIDR encoding follows the t6031-base convention
   (E cluster 0 at 0x0+i, P clusters N≥1 at 0x10000+(N<<8)+i). Not yet
   confirmed on T6040 silicon; kboot prints per-CPU MPIDRs and hard-fails on
   mismatch, so the first boot will confirm or correct these.
2. **PMGR window size**: 0x14000 follows the t8103/t8132 control-window convention; the ADT shows the full PMGR span is 0x1e0000 at the same base (verified), so the sub-window choice is safe. No power domains yet - the domain table needs a live PMGR dump.
3. **GPIO pin counts / I²C-SPI pinmux** inherited from the t8132 generation.
4. ATC PHY tunables (`atc-phy,t6040`) are absent from kboot_atc tables;
   IODeviceTree does not expose `apple,tunable-*`, so these need a
   proxyclient ADT dump.

I plan to run m1n1 + proxyclient on the donor machine to close 1–4 and will
update this series with measured values.

### Testing

- `make ARCH=arm64 apple/t6040-j614s.dtb` builds clean in-tree (arm64 defconfig).
- Full `Image.gz` build passes with the DT integrated.
- Standalone `dtc -@` compile + decompile round-trip verified.

Happy to restructure per reviewer preferences (e.g. splitting pinmux stubs,
dropping PMGR node entirely until the domain table exists).
