### PR TITLE
drm/apple: don't latch ->crashed on a poweroff swap timeout

### DIFF
--- a/drivers/gpu/drm/apple/iomfb_template.c
+++ b/drivers/gpu/drm/apple/iomfb_template.c
@@ -930,7 +930,24 @@ void DCP_FW_NAME(iomfb_poweroff)(struct apple_dcp *dcp)
 	swap_id = cookie->swap_id;
 	kref_put(&cookie->refcount, release_swap_cookie);
 	if (ret <= 0) {
-		dcp->crashed = true;
+		/*
+		 * The DCP did not acknowledge the poweroff clear swap.
+		 *
+		 * Do not latch ->crashed here: dcp_crtc_atomic_check() bails
+		 * out on that flag, so every subsequent atomic commit for this
+		 * device is rejected with -EINVAL, permanently. Nothing ever
+		 * clears it, so the display stays dark until reboot.
+		 *
+		 * This is not a crash. The DCP keeps working afterwards: it
+		 * renegotiates the link, publishes its mode list and asserts
+		 * HPD. ->crashed belongs to dcp_rtk_crashed(), the RTKit crash
+		 * callback, which also logs.
+		 *
+		 * Warn instead, so the timeout is at least visible.
+		 */
+		dev_warn(dcp->dev,
+			 "%s: timed out waiting for the poweroff clear swap; continuing\n",
+			 __func__);
 		return;
 	}
 


### PR DESCRIPTION
`iomfb_poweroff()` waits 50 ms for the poweroff clear swap and, on timeout, sets
`dcp->crashed` and returns **without logging anything**.

That flag is permanent and fatal. `dcp_crtc_atomic_check()` opens with
`if (dcp->crashed) return -EINVAL;` and nothing ever clears it, so from that
moment every atomic commit for the device is rejected and the display does not
come back until reboot.

It is not a crash. After the timeout the DCP keeps working — it renegotiates the
link, publishes its mode list and asserts HPD (`dcp_hotplug() connected:1
nr_modes:23`). `->crashed` is otherwise set only by `dcp_rtk_crashed()`, the
RTKit crash callback, which also logs. RTKit reported no crash in any of these
runs.

This keeps the control flow identical, leaves `->crashed` alone and emits a
`dev_warn` so the timeout is visible at all.

## How it was found

Observed on a MacBook Pro 13" M1 (j293) driving DisplayPort alt mode over USB-C.
Cold plug works; the first hot unplug kills the external output for the rest of
the boot. The compositor logs `failed to commit: Invalid argument` for all 23
modes the monitor offers, from 3440x1440 down to 640x480, and nothing in the
kernel log explains it — of the three `-EINVAL` exits in
`dcp_crtc_atomic_check()` only two log a `dev_err`, and the silent one is this.

Confirmed with kprobes on each of the three exits: **110 hits on the `->crashed`
branch, all returning -22, with zero "DCP has crashed" messages**. The timeout is
intermittent — it fired on 2 of 6 unplug cycles — which is why the failure looked
erratic.

With this applied, 6 unplug/replug cycles completed 8 modesets with no failures,
including the two cycles where the timeout did fire.

Full traces and the validation run are at
https://github.com/haripako/dp-altmode (`validacion/`).

## Notes

- Tested on `linux-asahi` 7.1.6 (`asahi-7.1.6-1`); the patch applies unchanged to
  `asahi` as of today, where the code is still present.
- `iomfb_template.c` is included once per IOMFB version, so this covers both the
  v12_3 and v13_3 paths.
- Reaching DisplayPort alt mode on M1 at all needed an out-of-tree device tree
  and a backport of the `fairydust` cd321x HPD forwarding. **This fix is
  independent of both** — it is in the poweroff path and applies to any CRTC
  being disabled, including the internal panel, though that path was not
  reproduced here.
