### PR TITLE
drm: apple: iomfb: fix framebuffer retirement on DCP 14.7

### DIFF
--- a/drivers/gpu/drm/apple/iomfb_template.c
+++ b/drivers/gpu/drm/apple/iomfb_template.c
@@ -739,8 +739,6 @@ static void dcp_swap_cleared(struct apple_dcp *dcp, void *data, void *cookie)
 		return;
 	}
 
-	/* TODO: Figure out how to clear surfaces for 14.x */
-#if DCP_FW_VER < DCP_FW_VERSION(14, 7, 0)
 	while (!list_empty(&dcp->swapped_out_fbs)) {
 		struct dcp_fb_reference *entry;
 		entry = list_first_entry(&dcp->swapped_out_fbs,
@@ -752,7 +750,6 @@ static void dcp_swap_cleared(struct apple_dcp *dcp, void *data, void *cookie)
 		list_del(&entry->head);
 		kfree(entry);
 	}
-#endif
 }
 
 static void dcp_swap_clear_started(struct apple_dcp *dcp, void *data,
@@ -1153,8 +1150,6 @@ static void dcp_swapped(struct apple_dcp *dcp, void *data, void *cookie)
 	}
 	dcp->swap_start = ktime_get();
 
-	/* TODO: Figure out how to clear surfaces on 14.x */
-#if DCP_FW_VER < DCP_FW_VERSION(14, 7, 0)
 	while (!list_empty(&dcp->swapped_out_fbs)) {
 		struct dcp_fb_reference *entry;
 		entry = list_first_entry(&dcp->swapped_out_fbs,
@@ -1166,7 +1161,6 @@ static void dcp_swapped(struct apple_dcp *dcp, void *data, void *cookie)
 		list_del(&entry->head);
 		kfree(entry);
 	}
-#endif
 }
 
 static void dcp_swap_started(struct apple_dcp *dcp, void *data, void *cookie)

--- a/drivers/gpu/drm/apple/iomfb_template.h
+++ b/drivers/gpu/drm/apple/iomfb_template.h
@@ -113,6 +113,9 @@ struct DCP_FW_NAME(dcp_swap_submit_req) {
 #if DCP_FW_VER >= DCP_FW_VERSION(13, 2, 0)
 	u32 unkU32Ptr;
 #endif
+#if DCP_FW_VER >= DCP_FW_VERSION(14, 7, 0)
+	u8 padding_14_7[0x234];
+#endif
 	u8 swap_null;
 	u8 surf_null[SWAP_SURFACES];
 #if DCP_FW_VER >= DCP_FW_VERSION(13, 2, 0)
@@ -124,12 +127,6 @@ struct DCP_FW_NAME(dcp_swap_submit_req) {
 	u8 unkU32out_null;
 #endif
 	u8 padding[1];
-#if DCP_FW_VER >= DCP_FW_VERSION(14, 7, 0)
-	u8 padding_14_7[0x1e9];
-	u8 unk_14_7_zero[0x46];
-	u32 unk_14_7_u32;
-	u8 unk_bool;
-#endif
 } __packed;
 
 struct DCP_FW_NAME(dcp_swap_submit_resp) {


### PR DESCRIPTION
## Summary

Fix framebuffer retirement with DCP firmware ABI 14.7 by:

- moving the 0x234-byte A407 extension before the pointer-null flags to match the firmware layout;
- enabling the existing `swapped_out_fbs` retirement logic for ABI 14.7.

Linux placed the null flags before the extension, so DCP did not process surface-clear requests. The workaround disabled framebuffer release for ABI 14.7.

## Testing

Tested on T6030/M3 Pro:

- 1,000 framebuffer replacements with 8 CRTC cycles;
- 200 primary-plane disable/re-enable cycles;
- all retained framebuffer references were released;
- no DART/IOVA faults, failed swaps, aborts, panics, or SErrors.