### PR TITLE
dt-bindings/arm64: apple: add Neural Engine hardware description

### DIFF
--- a/Documentation/devicetree/bindings/npu/apple,ane.yaml
+++ b/Documentation/devicetree/bindings/npu/apple,ane.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/npu/apple,ane.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Apple Neural Engine
+
+maintainers:
+  - Christian Tramnitz <christian@tramnitz.com>
+
+description: |
+  Apple SoCs contain a Neural Engine accelerator. The accelerator is connected
+  through three DART IOMMU instances.
+
+properties:
+  $nodename:
+    pattern: '^npu@[0-9a-f]+$'
+
+  compatible:
+    enum:
+      - apple,t8103-ane
+      - apple,t6000-ane
+      - apple,t8112-ane
+      - apple,t6020-ane
+
+  reg:
+    maxItems: 1
+
+  interrupts:
+    maxItems: 1
+
+  iommus:
+    minItems: 3
+    maxItems: 3
+
+  power-domains:
+    minItems: 1
+    maxItems: 5
+
+allOf:
+  - if:
+      properties:
+        compatible:
+          enum:
+            - apple,t8103-ane
+            - apple,t6000-ane
+    then:
+      properties:
+        power-domains:
+          minItems: 5
+          maxItems: 5
+    else:
+      properties:
+        power-domains:
+          maxItems: 1
+
+required:
+  - compatible
+  - reg
+  - interrupts
+  - iommus
+  - power-domains
+
+additionalProperties: false

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2597,6 +2597,7 @@ F:	Documentation/devicetree/bindings/leds/backlight/apple,dwi-bl.yaml
 F:	Documentation/devicetree/bindings/mailbox/apple,mailbox.yaml
 F:	Documentation/devicetree/bindings/mfd/apple,smc.yaml
 F:	Documentation/devicetree/bindings/net/bluetooth/brcm,bcm4377-bluetooth.yaml
+F:	Documentation/devicetree/bindings/npu/apple,ane.yaml
 F:	Documentation/devicetree/bindings/nvme/apple,nvme-ans.yaml
 F:	Documentation/devicetree/bindings/nvmem/apple,efuses.yaml
 F:	Documentation/devicetree/bindings/nvmem/apple,spmi-nvmem.yaml

--- a/arch/arm64/boot/dts/apple/t6001.dtsi
+++ b/arch/arm64/boot/dts/apple/t6001.dtsi
@@ -46,10 +46,12 @@
 	#include "t600x-die0.dtsi"
 	#include "t600x-dieX.dtsi"
 	#include "t600x-nvme.dtsi"
+	#include "t600x-ane.dtsi"
 };
 
 #include "t600x-gpio-pins.dtsi"
 #include "t600x-pmgr.dtsi"
+#include "t600x-ane-pmgr.dtsi"
 
 #undef DIE
 #undef DIE_NO

--- a/arch/arm64/boot/dts/apple/t6002-j375d.dts
+++ b/arch/arm64/boot/dts/apple/t6002-j375d.dts
@@ -299,4 +299,24 @@
 	apple,ppm-kp = <0.355>;
 };
 
+#define DIE
+#define DIE_NO 0
+#include "t600x-ane-pmgr.dtsi"
+&die0 {
+	#include "t600x-ane.dtsi"
+};
+
+#undef DIE
+#undef DIE_NO
+
+#define DIE _die1
+#define DIE_NO 1
+#include "t600x-ane-pmgr.dtsi"
+&die1 {
+	#include "t600x-ane.dtsi"
+};
+
+#undef DIE
+#undef DIE_NO
+
 #include "hwmon-fan-dual.dtsi"

--- a/arch/arm64/boot/dts/apple/t600x-ane-pmgr.dtsi
+++ b/arch/arm64/boot/dts/apple/t600x-ane-pmgr.dtsi
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+
+&DIE_NODE(pmgr) {
+	DIE_NODE(ps_ane_base): power-controller@c000 {
+		compatible = "apple,t6000-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc000 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = DIE_LABEL(ane_base);
+		power-domains = <&DIE_NODE(ps_ane_sys_cpu)>;
+	};
+
+	DIE_NODE(ps_ane_set1): power-controller@c008 {
+		compatible = "apple,t6000-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc008 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = DIE_LABEL(ane_set1);
+		power-domains = <&DIE_NODE(ps_ane_base)>;
+	};
+
+	DIE_NODE(ps_ane_set2): power-controller@c010 {
+		compatible = "apple,t6000-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc010 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = DIE_LABEL(ane_set2);
+		power-domains = <&DIE_NODE(ps_ane_base)>;
+	};
+
+	DIE_NODE(ps_ane_set3): power-controller@c018 {
+		compatible = "apple,t6000-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc018 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = DIE_LABEL(ane_set3);
+		power-domains = <&DIE_NODE(ps_ane_base)>;
+	};
+
+	DIE_NODE(ps_ane_set4): power-controller@c020 {
+		compatible = "apple,t6000-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc020 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = DIE_LABEL(ane_set4);
+		power-domains = <&DIE_NODE(ps_ane_base)>;
+	};
+
+	DIE_NODE(ps_ane_set5): power-controller@c028 {
+		compatible = "apple,t6000-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc028 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = DIE_LABEL(ane_set5);
+		power-domains = <&DIE_NODE(ps_ane_base)>;
+	};
+};

--- a/arch/arm64/boot/dts/apple/t600x-ane.dtsi
+++ b/arch/arm64/boot/dts/apple/t600x-ane.dtsi
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+
+	DIE_NODE(ane_dart0): iommu@285800000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x2 0x85800000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 771 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_ane_sys)>;
+	};
+
+	DIE_NODE(ane_dart1): iommu@285810000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x2 0x85810000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 771 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_ane_sys)>;
+	};
+
+	DIE_NODE(ane_dart2): iommu@285820000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x2 0x85820000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 771 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_ane_sys)>;
+	};
+
+	DIE_NODE(ane): npu@285c04000 {
+		compatible = "apple,t6000-ane";
+		reg = <0x2 0x85c04000 0x0 0x24000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 770 IRQ_TYPE_LEVEL_HIGH>;
+		iommus = <&DIE_NODE(ane_dart0) 0>, <&DIE_NODE(ane_dart1) 0>,
+			<&DIE_NODE(ane_dart2) 0>;
+		power-domains = <&DIE_NODE(ps_ane_set1)>,
+			<&DIE_NODE(ps_ane_set2)>, <&DIE_NODE(ps_ane_set3)>,
+			<&DIE_NODE(ps_ane_set4)>, <&DIE_NODE(ps_ane_set5)>;
+	};

--- a/arch/arm64/boot/dts/apple/t6021.dtsi
+++ b/arch/arm64/boot/dts/apple/t6021.dtsi
@@ -49,6 +49,7 @@
 	#include "t602x-die0.dtsi"
 	#include "t602x-dieX.dtsi"
 	#include "t602x-nvme.dtsi"
+	#include "t602x-ane.dtsi"
 };
 
 #include "t602x-gpio-pins.dtsi"

--- a/arch/arm64/boot/dts/apple/t6022-jxxxd.dtsi
+++ b/arch/arm64/boot/dts/apple/t6022-jxxxd.dtsi
@@ -283,3 +283,21 @@
 		/* 6: DP1 */
 	};
 };
+
+#define DIE
+#define DIE_NO 0
+&die0 {
+	#include "t602x-ane.dtsi"
+};
+
+#undef DIE
+#undef DIE_NO
+
+#define DIE _die1
+#define DIE_NO 1
+&die1 {
+	#include "t602x-ane.dtsi"
+};
+
+#undef DIE
+#undef DIE_NO

--- a/arch/arm64/boot/dts/apple/t602x-ane.dtsi
+++ b/arch/arm64/boot/dts/apple/t602x-ane.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+
+	DIE_NODE(ane_dart0): iommu@285800000 {
+		compatible = "apple,t6020-dart", "apple,t8110-dart";
+		reg = <0x2 0x85800000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 885 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_ane_sys)>;
+	};
+
+	DIE_NODE(ane_dart1): iommu@285810000 {
+		compatible = "apple,t6020-dart", "apple,t8110-dart";
+		reg = <0x2 0x85810000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 885 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_ane_sys)>;
+	};
+
+	DIE_NODE(ane_dart2): iommu@285820000 {
+		compatible = "apple,t6020-dart", "apple,t8110-dart";
+		reg = <0x2 0x85820000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 885 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_ane_sys)>;
+	};
+
+	DIE_NODE(ane): npu@285c04000 {
+		compatible = "apple,t6020-ane";
+		reg = <0x2 0x85c04000 0x0 0x24000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 884 IRQ_TYPE_LEVEL_HIGH>;
+		iommus = <&DIE_NODE(ane_dart0) 0>, <&DIE_NODE(ane_dart1) 0>,
+			<&DIE_NODE(ane_dart2) 0>;
+		power-domains = <&DIE_NODE(ps_ane_set4)>;
+	};

--- a/arch/arm64/boot/dts/apple/t8103-jxxx.dtsi
+++ b/arch/arm64/boot/dts/apple/t8103-jxxx.dtsi
@@ -304,6 +304,101 @@
 	clock-frequency = <900000000>;
 };
 
+&pmgr {
+	ps_ane_base: power-controller@c008 {
+		compatible = "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc008 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_base";
+		power-domains = <&ps_ane_sys_cpu>;
+	};
+
+	ps_ane_set1: power-controller@c010 {
+		compatible = "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc010 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_set1";
+		power-domains = <&ps_ane_base>;
+	};
+
+	ps_ane_set2: power-controller@c018 {
+		compatible = "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc018 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_set2";
+		power-domains = <&ps_ane_base>;
+	};
+
+	ps_ane_set3: power-controller@c020 {
+		compatible = "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc020 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_set3";
+		power-domains = <&ps_ane_base>;
+	};
+
+	ps_ane_set4: power-controller@c028 {
+		compatible = "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc028 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_set4";
+		power-domains = <&ps_ane_base>;
+	};
+
+	ps_ane_set5: power-controller@c030 {
+		compatible = "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc030 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_set5";
+		power-domains = <&ps_ane_base>;
+	};
+};
+
+&{/soc} {
+	ane_dart0: iommu@26b800000 {
+		compatible = "apple,t8103-dart";
+		reg = <0x2 0x6b800000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 417 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_ane_sys>;
+	};
+
+	ane_dart1: iommu@26b810000 {
+		compatible = "apple,t8103-dart";
+		reg = <0x2 0x6b810000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 417 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_ane_sys>;
+	};
+
+	ane_dart2: iommu@26b820000 {
+		compatible = "apple,t8103-dart";
+		reg = <0x2 0x6b820000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 417 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_ane_sys>;
+	};
+
+	ane: npu@26bc04000 {
+		compatible = "apple,t8103-ane";
+		reg = <0x2 0x6bc04000 0x0 0x24000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 416 IRQ_TYPE_LEVEL_HIGH>;
+		iommus = <&ane_dart0 0>, <&ane_dart1 0>, <&ane_dart2 0>;
+		power-domains = <&ps_ane_set1>, <&ps_ane_set2>,
+			<&ps_ane_set3>, <&ps_ane_set4>, <&ps_ane_set5>;
+	};
+};
+
 #include "hwmon-common.dtsi"
 
 #include "spi1-nvram.dtsi"

--- a/arch/arm64/boot/dts/apple/t8112-ane.dtsi
+++ b/arch/arm64/boot/dts/apple/t8112-ane.dtsi
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+
+&pmgr {
+	ps_ane_cpu: power-controller@c008 {
+		compatible = "apple,t8112-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		reg = <0xc008 4>;
+		#power-domain-cells = <0>;
+		#reset-cells = <0>;
+		label = "ane_cpu";
+		power-domains = <&ps_ane_sys>;
+	};
+};
+
+&{/soc} {
+	ane_dart0: iommu@26b800000 {
+		compatible = "apple,t8110-dart";
+		reg = <0x2 0x6b800000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 521 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_ane_sys>;
+	};
+
+	ane_dart1: iommu@26b810000 {
+		compatible = "apple,t8110-dart";
+		reg = <0x2 0x6b810000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 521 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_ane_sys>;
+	};
+
+	ane_dart2: iommu@26b820000 {
+		compatible = "apple,t8110-dart";
+		reg = <0x2 0x6b820000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 521 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_ane_sys>;
+	};
+
+	ane: npu@26bc04000 {
+		compatible = "apple,t8112-ane";
+		reg = <0x2 0x6bc04000 0x0 0x24000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 520 IRQ_TYPE_LEVEL_HIGH>;
+		iommus = <&ane_dart0 0>, <&ane_dart1 0>, <&ane_dart2 0>;
+		power-domains = <&ps_ane_cpu>;
+	};
+};

--- a/arch/arm64/boot/dts/apple/t8112-jxxx.dtsi
+++ b/arch/arm64/boot/dts/apple/t8112-jxxx.dtsi
@@ -285,6 +285,8 @@
 	clock-frequency = <900000000>;
 };
 
+#include "t8112-ane.dtsi"
+
 #include "hwmon-common.dtsi"
 
 #include "spi1-nvram.dtsi"


### PR DESCRIPTION
## Summary

Add a DeviceTree binding and hardware descriptions for the Apple Neural
Engine (ANE) on T8103, T600x, T8112 and T602x SoCs.

The ANE is described as an NPU device connected to three Apple DART IOMMU
instances. The DARTs are modeled as normal IOMMU providers and referenced
through the ANE `iommus` property, rather than exposing DART resources
through the accelerator node.

This series contains only hardware description and does not depend on a
particular ANE driver implementation.

## SoC support

* T8103 / M1
* T6000/T6001/T6002 / M1 Pro, Max and Ultra
* T8112 / M2
* T6020/T6021/T6022 / M2 Pro, Max and Ultra

For T600x, only the primary ANE is described. The existing PMGR description
already marks the second ANE power-domain path as disabled on shipping
hardware, so this series intentionally leaves it disabled.

The historical `apple,always-on` workaround used by earlier out-of-tree ANE
work is also intentionally not carried over.

## Data provenance

The T8103 description is based on Eileen Yoon's earlier ANE work, referenced
from the corresponding commit.

T600x, T8112 and T602x register, interrupt and power-domain data are derived
from Apple DeviceTree data.

The T6020/H14G configuration has additionally been runtime-tested on M2 Max
hardware. T600x has not been runtime-tested as part of this series.

## Testing

The following checks were run against the series:

```text
make ARCH=arm64 \
  dt_binding_check \
  DT_SCHEMA_FILES=Documentation/devicetree/bindings/npu/apple,ane.yaml

make ARCH=arm64 \
  dtbs_check \
  DT_SCHEMA_FILES=Documentation/devicetree/bindings/npu/apple,ane.yaml

./scripts/checkpatch.pl --strict --git \
  71d72e6f41342d0afb45a530e333c8653ccf0d7e..HEAD
```

`dt_binding_check` and `dtbs_check` complete successfully.

`checkpatch.pl --strict` reports no errors or relevant checks.