### PR TITLE
soc: apple: {sep,aop}: log the endpoints and services the firmware offers

### DIFF
--- a/drivers/soc/apple/aop.rs
+++ b/drivers/soc/apple/aop.rs
@@ -765,6 +765,12 @@ impl AopData {
             b"las" => c_str!("las"),
             b"als" => c_str!("als"),
             _ => {
+                dev_info!(
+                    self.dev,
+                    "No driver for service {:?} on endpoint {}",
+                    core::str::from_utf8(name),
+                    ep.index
+                );
                 return Ok(());
             }
         };

--- a/drivers/soc/apple/sep.rs
+++ b/drivers/soc/apple/sep.rs
@@ -46,14 +46,15 @@ const MSG_BOOT_TZ0_ACK1: u64 = 0x69;
 const MSG_BOOT_TZ0_ACK2: u64 = 0xD2;
 const MSG_BOOT_IMG4_ACK: u64 = 0x6A;
 const MSG_ADVERTISE_EP: u64 = 0;
+const MSG_ADVERTISE_OOL: u64 = 1;
 const EP_DISCOVER: u64 = 0xFD;
 const EP_SHMEM: u64 = 0xFE;
 const EP_BOOT: u64 = 0xFF;
 
 const MSG_TYPE_SHIFT: u32 = 16;
 const MSG_TYPE_MASK: u64 = 0xFF;
-//const MSG_PARAM_SHIFT: u32 = 24;
-//const MSG_PARAM_MASK: u64 = 0xFF;
+const MSG_PARAM_SHIFT: u32 = 24;
+const MSG_PARAM_MASK: u64 = 0xFF;
 
 const MSG_EP_MASK: u64 = 0xFF;
 const MSG_DATA_SHIFT: u32 = 32;
@@ -257,19 +258,27 @@ impl SepData {
     }
     fn process_discover_msg(&self, msg: Message) {
         let ty = (msg.msg0 >> MSG_TYPE_SHIFT) & MSG_TYPE_MASK;
-        //let data = (msg.msg0 >> MSG_DATA_SHIFT) as u32;
-        //let param = (msg.msg0 >> MSG_PARAM_SHIFT) & MSG_PARAM_MASK;
+        let data = (msg.msg0 >> MSG_DATA_SHIFT) as u32;
+        let param = (msg.msg0 >> MSG_PARAM_SHIFT) & MSG_PARAM_MASK;
         match ty {
             MSG_ADVERTISE_EP => {
-                /*dev_info!(
+                dev_info!(
                     self.dev,
                     "Got endpoint {:?} at {}",
                     core::str::from_utf8(&data.to_be_bytes()),
                     param
-                );*/
+                );
+            }
+            MSG_ADVERTISE_OOL => {
+                dev_info!(
+                    self.dev,
+                    "Endpoint {} OOL buffer sizes {:#010x}",
+                    param,
+                    data
+                );
             }
             _ => {
-                //dev_warn!(self.dev, "Unknown discovery message type: {}", ty);
+                dev_warn!(self.dev, "Unknown discovery message type: {}", ty);
             }
         }
     }


### PR DESCRIPTION
Log the endpoints SEPOS advertises and the AOP services that no driver claims, once per boot during `probe()`, at the same level as the RTKit syslog output these coprocessors already emit. Both drivers discard that description of what the firmware offers.

## Changes

- `sep.rs`: enable the `dev_info!` in `process_discover_msg()` that prints each advertised SEPOS endpoint, with its four-character name and endpoint number, and the `dev_warn!` for unknown discovery message types. Restore the two constants they need, `MSG_PARAM_SHIFT` and `MSG_PARAM_MASK`.
- `sep.rs`: name discovery message type 1 `MSG_ADVERTISE_OOL` and log it. This is what `AppleSEPManager` calls the OOL advertisement: the endpoint's out-of-line buffer size bounds in pages, packed into the data word. SEPOS sends one per endpoint right after the type 0 message, so without this the newly enabled warning fires seven times per boot.
- `aop.rs`: in `register_service()`, log the name and endpoint of any announced EPIC service other than `aop-audio`, `las`, or `als` before returning.

`dev_dbg!` is not an option here. Rust's `dev_dbg!` routes to `Device::pr_dbg()`, which is gated on `cfg!(debug_assertions)` and does not participate in dynamic debug, so it compiles to nothing unless `CONFIG_RUST_DEBUG_ASSERTIONS` is set.

## Why this matters

The set of endpoints SEPOS starts has never been visible from Linux on any board, and AOP services with no driver leave no trace. Both lists are the first thing anyone working on these coprocessors needs.

## Output

On a MacBook Pro 16-inch 2021 (`apple,j316s` / `apple,t6000`), whose AOP node binds only `aop-audio` and `als`, the patched kernel prints during probe:

```
apple_sep 396400000.sep: Got endpoint Ok("hibe") at 20
apple_sep 396400000.sep: Endpoint 20 OOL buffer sizes 0x01010101
apple_sep 396400000.sep: Got endpoint Ok("stac") at 24
apple_sep 396400000.sep: Endpoint 24 OOL buffer sizes 0x02020202
apple_sep 396400000.sep: Got endpoint Ok("cntl") at 0
apple_sep 396400000.sep: Endpoint 0 OOL buffer sizes 0x00000000
apple_sep 396400000.sep: Got endpoint Ok("xarm") at 19
apple_sep 396400000.sep: Endpoint 19 OOL buffer sizes 0x02020202
apple_sep 396400000.sep: Got endpoint Ok("xars") at 16
apple_sep 396400000.sep: Endpoint 16 OOL buffer sizes 0x02020202
apple_sep 396400000.sep: Got endpoint Ok("pnon") at 21
apple_sep 396400000.sep: Endpoint 21 OOL buffer sizes 0x02020404
apple_sep 396400000.sep: Got endpoint Ok("hdcp") at 14
apple_sep 396400000.sep: Endpoint 14 OOL buffer sizes 0x01010101
```
```
apple_aop 293c00000.aop: No driver for service Ok("wakehint") on endpoint 37
apple_aop 293c00000.aop: No driver for service Ok("accel") on endpoint 33
apple_aop 293c00000.aop: No driver for service Ok("gyro") on endpoint 34
apple_aop 293c00000.aop: No driver for service Ok("als-temp") on endpoint 43
apple_aop 293c00000.aop: No driver for service Ok("cma") on endpoint 42
apple_aop 293c00000.aop: No driver for service Ok("devmotion6") on endpoint 41
apple_aop 293c00000.aop: No driver for service Ok("SPUApp") on endpoint 32
apple_aop 293c00000.aop: No driver for service Ok("aop-voicetrigger") on endpoint 40
```

## Testing

Compile-tested against `asahi-7.1.6-1` with rustc 1.93.1, and runtime-tested on the `j316s` above with the `sep` node enabled:

- `drivers/soc/apple/sep.o` and `aop.o` build before and after, `CLIPPY=1` introduces no new warnings, and `rustfmt --check` passes.
- The output above is the complete non-RTKit `apple_sep` and `apple_aop` output of one boot.
- No `Unknown discovery message type` warning fires, so types 0 and 1 are the only discovery messages this SEPOS sends.
- The endpoint set matches an earlier kprobe capture from the unpatched driver.

This change is independent of #592 and applies to `asahi-wip` in either order.
