### PR TITLE
arm64: dts: apple: t8103: Add SIO alias

### DIFF
--- a/arch/arm64/boot/dts/apple/t8103-jxxx.dtsi
+++ b/arch/arm64/boot/dts/apple/t8103-jxxx.dtsi
@@ -22,6 +22,7 @@
 		disp0_piodma = &disp0_piodma;
 		serial0 = &serial0;
 		serial2 = &serial2;
+		sio = &sio;
 		wifi0 = &wifi0;
 		atcphy0 = &atcphy0;
 		atcphy1 = &atcphy1;


### PR DESCRIPTION
m1n1 looks up the SIO node through the `sio` FDT alias when setting up SIO firmware data. The common T8103 device trees currently lack this alias, so m1n1 silently skips SIO setup and leaves the node disabled.

Add the alias to `t8103-jxxx.dtsi`, matching the T600x device trees.

Tested on a J313 MacBook Air (M1) with stock m1n1 1.6.1.

Before this change:

- `/proc/device-tree/aliases/sio` is absent
- SIO remains `status = "disabled"`
- `dcp-dp-audio` reports `No DMA device`
- no DisplayPort ALSA playback device is created

With this change:

- `/proc/device-tree/aliases/sio` resolves to `/soc/sio@236400000`
- m1n1 sets SIO to `status = "okay"`
- `apple-sio` initializes RTKit successfully and reports SIO protocol v9
- with `appledrm.hdmi_audio=1`, `aplay -l` exposes `Apple DisplayPort`
- USB-C DisplayPort audio was verified working through PipeWire on a Samsung M70D monitor

The DTBs for J274, J293, J313, J456 and J457 build successfully with this change.