### PR TITLE
dcp on m3 devices

### DIFF
--- a/arch/arm64/boot/dts/apple/t6030-j514s.dts
+++ b/arch/arm64/boot/dts/apple/t6030-j514s.dts
@@ -17,6 +17,13 @@
 	model = "Apple MacBook Pro (14-inch, M3 Pro, Nov 2023)";
 };
 
+&panel {
+	compatible = "apple,panel-j514s", "apple,panel-mini-led", "apple,panel";
+	width-mm = <302>;
+	height-mm = <196>;
+	adj-height-mm = <189>;
+};
+
 &framebuffer0 {
 	power-domains = <&ps_disp_cpu>;
 };

--- a/arch/arm64/boot/dts/apple/t6030-j516s.dts
+++ b/arch/arm64/boot/dts/apple/t6030-j516s.dts
@@ -17,6 +17,13 @@
 	model = "Apple MacBook Pro (16-inch, M3 Pro, Nov 2023)";
 };
 
+&panel {
+	compatible = "apple,panel-j516s", "apple,panel-mini-led", "apple,panel";
+	width-mm = <346>;
+	height-mm = <223>;
+	adj-height-mm = <216>;
+};
+
 &framebuffer0 {
 	power-domains = <&ps_disp_cpu>;
 };

--- a/arch/arm64/boot/dts/apple/t6030.dtsi
+++ b/arch/arm64/boot/dts/apple/t6030.dtsi
@@ -617,6 +617,94 @@
 			#sound-dai-cells = <1>;
 		};
 
+		disp_dart: iommu@28d304000 {
+			compatible = "apple,t6030-dart", "apple,t8110-dart";
+			reg = <0x2 0x8d304000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 609 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+			power-domains = <&ps_disp_cpu>;
+			apple,dma-range = <0x100 0x0 0x10 0x0>;
+		};
+
+		dcp_dart: iommu@28d30c000 {
+			compatible = "apple,t6030-dart", "apple,t8110-dart";
+			reg = <0x2 0x8d30c000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 609 IRQ_TYPE_LEVEL_HIGH>;
+			power-domains = <&ps_disp_cpu>;
+			apple,dma-range = <0x100 0x0 0x10 0x0>;
+		};
+
+		dcp_mbox: mbox@28ec08000 {
+			compatible = "apple,t6030-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x8ec08000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 589 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 590 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 591 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 592 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			power-domains = <&ps_disp_cpu>;
+		};
+
+		clk_disp: clock-disp {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <257142848>;
+			clock-output-names = "clk_disp";
+		};
+
+		dcp: dcp@28ec00000 {
+			compatible = "apple,t6030-dcp", "apple,dcp";
+			mboxes = <&dcp_mbox>;
+			mbox-names = "mbox";
+			iommus = <&dcp_dart 5>;
+			reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3", "disp-4";
+			reg = <0x2 0x8ec00000 0x0 0x4000>, // check?
+				<0x2 0xd0000000 0x0 0x690000>,
+                                <0x2 0xd0800000 0x0 0x690000>,
+                                <0x2 0xd1320000 0x0 0x4000>,
+                                <0x2 0xd1344000 0x0 0x4000>,
+                                <0x2 0xd2800000 0x0 0x800000>;
+			apple,bw-scratch = <&pmgr_dcp 0 5 0x988>;
+			apple,iomfb-surfaces = <1 1 0 1>;
+			power-domains = <&ps_disp_cpu>;
+			resets = <&ps_disp_cpu>;
+			clocks = <&clk_disp>;
+			phandle = <&dcp>;
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
+
+			disp0_piodma: piodma {
+				iommus = <&disp_dart 4>;
+				phandle = <&disp0_piodma>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					/* dcp_audio: endpoint { */
+					/* 	remote-endpoint = <&dpaudio0_dcp>; */
+					/* }; */
+				};
+			};
+		};
+
+		display: display-subsystem {
+			compatible = "apple,display-subsystem";
+			iommus = <&disp_dart 0>;
+			/* generate phandle explicitly for use in loader */
+			phandle = <&display>;
+		};
+
 		pmgr_gfx: power-management@290e80000 {
 			compatible = "apple,t6030-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 			#address-cells = <1>;
@@ -781,6 +869,12 @@
 					 <APPLE_PINMUX(165, 1)>,
 					 <APPLE_PINMUX(166, 1)>;
 			};
+		};
+
+		pmgr_dcp: power-management@3503d0000 {
+			reg = <0x3 0x503d0000 0x0 0x4000>;
+			reg-names = "dcp-fw-pmgr";
+			#apple,bw-scratch-cells = <3>;
 		};
 
 		pmgr: power-management@350700000 {

--- a/arch/arm64/boot/dts/apple/t6031-base.dtsi
+++ b/arch/arm64/boot/dts/apple/t6031-base.dtsi
@@ -497,6 +497,69 @@
 		clock-output-names = "nco_ref";
 	};
 
+	clk_disp0: clock-disp {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <257142848>;
+		clock-output-names = "clk_disp";
+	};
+
+	clk_dispext0: clock-dispext0 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext0";
+	};
+
+	clk_dispext0_die1: clock-dispext0_die1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext0_die1";
+	};
+
+	clk_dispext1: clock-dispext1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext1";
+	};
+
+	clk_dispext1_die1: clock-dispext1_die1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext1_die1";
+	};
+
+	clk_dispext2: clock-dispext2 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext2";
+	};
+
+	clk_dispext2_die1: clock-dispext2_die1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext2_die1";
+	};
+
+	clk_dispext3: clock-dispext3 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext3";
+	};
+
+	clk_dispext3_die1: clock-dispext3_die1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext3_die1";
+	};
+
 	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/arch/arm64/boot/dts/apple/t6031-die0.dtsi
+++ b/arch/arm64/boot/dts/apple/t6031-die0.dtsi
@@ -32,6 +32,12 @@
 		power-domains = <&ps_aic>;
 	};
 
+	pmgr_dcp: power-management@2903d0000 {
+		reg = <0x2 0x903d0000 0x0 0x4000>;
+		reg-names = "dcp-fw-pmgr";
+		#apple,bw-scratch-cells = <3>;
+	};
+
 	nub_spmi: spmi@2a1014000 {
 		compatible = "apple,t6031-spmi", "apple,t8103-spmi";
 		reg = <0x2 0xa1014000 0x0 0x100>;
@@ -326,6 +332,86 @@
 			apple,fifo-size = <0x800>;
 			apple,helper-cpu = <&mtp>;
 		};
+	};
+
+	disp0_dart: iommu@385304000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x3 0x85304000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 1008 IRQ_TYPE_LEVEL_HIGH>;
+		status = "disabled";
+		power-domains = <&ps_disp_cpu>;
+		apple,dma-range = <0x100 0x0 0x10 0x0>;
+	};
+
+	dcp_dart: iommu@38530c000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x3 0x8530c000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 1008 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&ps_disp_cpu>;
+		apple,dma-range = <0x100 0x0 0x10 0x0>;
+	};
+
+	dcp_mbox: mbox@386c08000 {
+		compatible = "apple,t6031-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x3 0x86c08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 1029 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 1030 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 1031 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 1032 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&ps_disp_cpu>;
+	};
+
+	dcp: dcp@386c00000 {
+		compatible = "apple,t6031-dcp", "apple,dcp";
+		mboxes = <&dcp_mbox>;
+		mbox-names = "mbox";
+		iommus = <&dcp_dart 5>;
+		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+		reg = <0x3 0x86c00000 0x0 0x4000>, // check?
+			<0x3 0x84000000 0x0 0x4000000>,
+			<0x3 0x85320000 0x0 0x4000>,
+			<0x3 0x85344000 0x0 0x4000>,
+			<0x3 0x86800000 0x0 0x800000>;
+		apple,bw-scratch = <&pmgr_dcp 0 4 0x1208>;
+		apple,iomfb-surfaces = <1 1 0 1>;
+		power-domains = <&ps_disp_cpu>;
+		resets = <&ps_disp_cpu>;
+		clocks = <&clk_disp0>;
+		phandle = <&dcp>;
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		disp0_piodma: piodma {
+			iommus = <&disp0_dart 4>;
+			phandle = <&disp0_piodma>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				/* dcp_audio: endpoint { */
+				/* 	remote-endpoint = <&dpaudio0_dcp>; */
+				/* }; */
+			};
+		};
+	};
+
+	display: display-subsystem {
+		compatible = "apple,display-subsystem";
+		iommus = <&disp0_dart 0>;
+		/* generate phandle explicitly for use in loader */
+		phandle = <&display>;
 	};
 
 	isp_dart0: iommu@38e4a8000 {

--- a/arch/arm64/boot/dts/apple/t6031-dieX.dtsi
+++ b/arch/arm64/boot/dts/apple/t6031-dieX.dtsi
@@ -140,6 +140,158 @@
 		power-domains = <&DIE_NODE(ps_avd_sys)>;
 	};
 
+	DIE_NODE(dispext3_dart): iommu@2c9304000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x2 0xc9304000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1155 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext3_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext3_dart): iommu@2c930c000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x2 0xc930c000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1155 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext3_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext3_mbox): mbox@2cac08000 {
+		compatible = "apple,t6031-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x2 0xcac08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1176 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1177 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1178 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1179 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_dispext3_cpu)>;
+		resets = <&DIE_NODE(ps_dispext3_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext3):  dcp@2cac00000 {
+		compatible = "apple,t6031-dcpext", "apple,dcpext";
+		mboxes = <&DIE_NODE(dcpext3_mbox)>;
+		mbox-names = "mbox";
+		iommus = <&DIE_NODE(dcpext3_dart) 5 0x100 0x0 0x10 0x0>;
+
+		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+		reg = <0x2 0xcac00000 0x0 0x4000>,
+			<0x2 0xc8000000 0x0 0x4000000>,
+			<0x2 0xc9320000 0x0 0x4000>,
+			<0x2 0xc9344000 0x0 0x4000>,
+			<0x2 0xca800000 0x0 0x800000>;
+		apple,bw-scratch = <&pmgr_dcp 0 4 0x1228>;
+		apple,iomfb-surfaces = <1 1 0 1>;
+		power-domains = <&DIE_NODE(ps_dispext3_cpu)>;
+		resets = <&DIE_NODE(ps_dispext3_cpu)>;
+		clocks = <&DIE_NODE(clk_dispext3)>;
+		phandle = <&DIE_NODE(dcpext3)>;
+		apple,dcp-index = <3>;
+		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		piodma {
+			iommus = <&DIE_NODE(dispext3_dart) 4 0x100 0x0 0x10 0x0>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				/* DIE_NODE(dcpext3_audio): endpoint { */
+				/* 	remote-endpoint = <&DIE_NODE(dpaudio1_dcp)>; */
+				/* }; */
+			};
+		};
+	};
+
+	DIE_NODE(dispext0_dart): iommu@305304000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x3 0x5304000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1047 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext0_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext0_dart): iommu@30530c000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x3 0x530c000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1047 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext0_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext0_mbox): mbox@306c08000 {
+		compatible = "apple,t6031-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x3 0x6c08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1068 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1069 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1070 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1071 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_dispext0_cpu)>;
+		resets = <&DIE_NODE(ps_dispext0_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext0):  dcp@306c00000 {
+		compatible = "apple,t6031-dcpext", "apple,dcpext";
+		mboxes = <&DIE_NODE(dcpext0_mbox)>;
+		mbox-names = "mbox";
+		iommus = <&DIE_NODE(dcpext0_dart) 5 0x100 0x0 0x10 0x0>;
+
+		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+		reg = <0x3 0x6c00000 0x0 0x4000>,
+			<0x2 0x4000000 0x0 0x4000000>,
+			<0x2 0x5320000 0x0 0x4000>,
+			<0x2 0x5344000 0x0 0x4000>,
+			<0x2 0x6800000 0x0 0x800000>;
+		apple,bw-scratch = <&pmgr_dcp 0 4 0x1210>;
+		apple,iomfb-surfaces = <1 1 0 1>;
+		power-domains = <&DIE_NODE(ps_dispext0_cpu)>;
+		resets = <&DIE_NODE(ps_dispext0_cpu)>;
+		clocks = <&DIE_NODE(clk_dispext0)>;
+		phandle = <&DIE_NODE(dcpext0)>;
+		apple,dcp-index = <0>;
+		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		piodma {
+			iommus = <&DIE_NODE(dispext0_dart) 4 0x100 0x0 0x10 0x0>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				/* DIE_NODE(dcpext0_audio): endpoint { */
+				/* 	remote-endpoint = <&DIE_NODE(dpaudio1_dcp)>; */
+				/* }; */
+			};
+		};
+	};
+
 	DIE_NODE(sio_dart): iommu@391004000 {
 		compatible = "apple,t6031-dart", "apple,t8110-dart";
 		reg = <0x3 0x91004000 0x0 0x4000>;
@@ -180,6 +332,158 @@
 		#size-cells = <1>;
 
 		reg = <0x4 0x8e80000 0 0x4000>;
+	};
+
+	DIE_NODE(dispext1_dart): iommu@449304000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x4 0x49304000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1083 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext1_dart): iommu@44930c000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x4 0x4930c000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1083 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext1_mbox): mbox@44ac08000 {
+		compatible = "apple,t6031-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x4 0x4ac08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1104 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1105 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1106 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1107 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu)>;
+		resets = <&DIE_NODE(ps_dispext1_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext1):  dcp@44ac00000 {
+		compatible = "apple,t6031-dcpext", "apple,dcpext";
+		mboxes = <&DIE_NODE(dcpext1_mbox)>;
+		mbox-names = "mbox";
+		iommus = <&DIE_NODE(dcpext1_dart) 5 0x100 0x0 0x10 0x0>;
+
+		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+		reg = <0x4 0x4ac00000 0x0 0x4000>,
+			<0x4 0x48000000 0x0 0x4000000>,
+			<0x4 0x49320000 0x0 0x4000>,
+			<0x4 0x49344000 0x0 0x4000>,
+			<0x4 0x4a800000 0x0 0x800000>;
+		apple,bw-scratch = <&pmgr_dcp 0 4 0x1218>;
+		apple,iomfb-surfaces = <1 1 0 1>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu)>;
+		resets = <&DIE_NODE(ps_dispext1_cpu)>;
+		clocks = <&DIE_NODE(clk_dispext1)>;
+		phandle = <&DIE_NODE(dcpext1)>;
+		apple,dcp-index = <1>;
+		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		piodma {
+			iommus = <&DIE_NODE(dispext1_dart) 4 0x100 0x0 0x10 0x0>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				/* DIE_NODE(dcpext1_audio): endpoint { */
+				/* 	remote-endpoint = <&DIE_NODE(dpaudio1_dcp)>; */
+				/* }; */
+			};
+		};
+	};
+
+	DIE_NODE(dispext2_dart): iommu@44d304000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x4 0x4d304000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1119 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext2_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext2_dart): iommu@44d30c000 {
+		compatible = "apple,t6031-dart", "apple,t8110-dart";
+		reg = <0x4 0x4d30c000 0x0 0x4000>;
+		#iommu-cells = <5>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1119 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext2_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext2_mbox): mbox@44ec08000 {
+		compatible = "apple,t6031-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x4 0x4ec08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1140 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1141 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1142 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1143 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_dispext2_cpu)>;
+		resets = <&DIE_NODE(ps_dispext2_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext2):  dcp@44ec00000 {
+		compatible = "apple,t6031-dcpext", "apple,dcpext";
+		mboxes = <&DIE_NODE(dcpext2_mbox)>;
+		mbox-names = "mbox";
+		iommus = <&DIE_NODE(dcpext2_dart) 5 0x100 0x0 0x10 0x0>;
+
+		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+		reg = <0x4 0x4ec00000 0x0 0x4000>,
+			<0x4 0x4c000000 0x0 0x4000000>,
+			<0x4 0x4d320000 0x0 0x4000>,
+			<0x4 0x4d344000 0x0 0x4000>,
+			<0x4 0x4e800000 0x0 0x800000>;
+		apple,bw-scratch = <&pmgr_dcp 0 4 0x1220>;
+		apple,iomfb-surfaces = <1 1 0 1>;
+		power-domains = <&DIE_NODE(ps_dispext2_cpu)>;
+		resets = <&DIE_NODE(ps_dispext2_cpu)>;
+		clocks = <&DIE_NODE(clk_dispext2)>;
+		phandle = <&DIE_NODE(dcpext2)>;
+		apple,dcp-index = <2>;
+		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		piodma {
+			iommus = <&DIE_NODE(dispext2_dart) 4 0x100 0x0 0x10 0x0>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				/* DIE_NODE(dcpext2_audio): endpoint { */
+				/* 	remote-endpoint = <&DIE_NODE(dpaudio1_dcp)>; */
+				/* }; */
+			};
+		};
 	};
 
 	DIE_NODE(usb4_0_mbox): mailbox@701108000 {

--- a/arch/arm64/boot/dts/apple/t6031-j514c.dts
+++ b/arch/arm64/boot/dts/apple/t6031-j514c.dts
@@ -17,6 +17,13 @@
 	model = "Apple MacBook Pro (14-inch, M3 Max, 16 CPU cores, Nov 2023)";
 };
 
+&panel {
+	compatible = "apple,panel-j514c", "apple,panel-mini-led", "apple,panel";
+	width-mm = <302>;
+	height-mm = <196>;
+	adj-height-mm = <189>;
+};
+
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j514c.bin";
 };

--- a/arch/arm64/boot/dts/apple/t6031-j516c.dts
+++ b/arch/arm64/boot/dts/apple/t6031-j516c.dts
@@ -17,6 +17,13 @@
 	model = "Apple MacBook Pro (16-inch, M3 Max, 16 CPU cores, Nov 2023)";
 };
 
+&panel {
+	compatible = "apple,panel-j516c", "apple,panel-mini-led", "apple,panel";
+	width-mm = <346>;
+	height-mm = <223>;
+	adj-height-mm = <216>;
+};
+
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j516c.bin";
 };

--- a/arch/arm64/boot/dts/apple/t6031.dtsi
+++ b/arch/arm64/boot/dts/apple/t6031.dtsi
@@ -22,6 +22,13 @@
 	#address-cells = <2>;
 	#size-cells = <2>;
 
+	aliases {
+		dcpext0 = &dcpext0;
+		dcpext1 = &dcpext1;
+		dcpext2 = &dcpext2;
+		dcpext3 = &dcpext3;
+	};
+
 	soc: soc {
 		compatible = "simple-bus";
 		#address-cells = <2>;

--- a/arch/arm64/boot/dts/apple/t6032.dtsi
+++ b/arch/arm64/boot/dts/apple/t6032.dtsi
@@ -24,6 +24,17 @@
 	#address-cells = <2>;
 	#size-cells = <2>;
 
+	aliases {
+		dcpext0 = &dcpext0;
+		dcpext1 = &dcpext1;
+		dcpext2 = &dcpext2;
+		dcpext3 = &dcpext3;
+		dcpext4 = &dcpext0_die1;
+		dcpext5 = &dcpext1_die1;
+		dcpext6 = &dcpext2_die1;
+		dcpext7 = &dcpext3_die1;
+	};
+
 	cpus {
 		#address-cells = <2>;
 		#size-cells = <0>;

--- a/arch/arm64/boot/dts/apple/t6032.dtsi
+++ b/arch/arm64/boot/dts/apple/t6032.dtsi
@@ -356,14 +356,6 @@
 #undef DIE
 #undef DIE_NO
 
-/* delete non-present DISP power-states */
-/delete-node/ &ps_disp_cpu;
-/delete-node/ &ps_disp_cpu_die1;
-/delete-node/ &ps_disp_fe;
-/delete-node/ &ps_disp_fe_die1;
-/delete-node/ &ps_disp_sys;
-/delete-node/ &ps_disp_sys_die1;
-
 /* delete non-present ISP power-states */
 /delete-node/ &isp_dart0;
 /delete-node/ &isp_dart1;

--- a/arch/arm64/boot/dts/apple/t6034-j514m.dts
+++ b/arch/arm64/boot/dts/apple/t6034-j514m.dts
@@ -17,6 +17,13 @@
 	model = "Apple MacBook Pro (14-inch, M3 Max, 14 CPU cores, Nov 2023)";
 };
 
+&panel {
+	compatible = "apple,panel-j514m", "apple,panel-mini-led", "apple,panel";
+	width-mm = <302>;
+	height-mm = <196>;
+	adj-height-mm = <189>;
+};
+
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j514m.bin";
 };

--- a/arch/arm64/boot/dts/apple/t6034-j516m.dts
+++ b/arch/arm64/boot/dts/apple/t6034-j516m.dts
@@ -17,6 +17,13 @@
 	model = "Apple MacBook Pro (16-inch, M3 Max, 14 CPU cores, Nov 2023)";
 };
 
+&panel {
+	compatible = "apple,panel-j516m", "apple,panel-mini-led", "apple,panel";
+	width-mm = <346>;
+	height-mm = <223>;
+	adj-height-mm = <216>;
+};
+
 &mtp_mt {
 	firmware-name = "apple/tpmtfw-j516m.bin";
 };

--- a/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
+++ b/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
@@ -80,6 +80,12 @@
 	};
 };
 
+&dcp {
+	panel: panel {
+		apple,max-brightness = <500>;
+	};
+};
+
 &serial0 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
+++ b/arch/arm64/boot/dts/apple/t603x-j514-j516.dtsi
@@ -41,6 +41,10 @@
 		usb4_1_nhi = &usb4_1_nhi;
 		usb4_2_rc = &usb4_2_acio;
 		usb4_2_nhi = &usb4_2_nhi;
+
+		dcp = &dcp;
+		disp0 = &display;
+		disp0_piodma = &disp0_piodma;
 	};
 
 	chosen {

--- a/arch/arm64/boot/dts/apple/t8122-j504.dts
+++ b/arch/arm64/boot/dts/apple/t8122-j504.dts
@@ -31,6 +31,13 @@
 	};
 };
 
+&panel {
+	compatible = "apple,panel-j504", "apple,panel";
+	width-mm = <302>;
+	height-mm = <196>;
+	adj-height-mm = <189>;
+};
+
 &wifi0 {
 	brcm,board-type = "apple,tresco";
 };

--- a/arch/arm64/boot/dts/apple/t8122-j613.dts
+++ b/arch/arm64/boot/dts/apple/t8122-j613.dts
@@ -31,6 +31,13 @@
 	};
 };
 
+&panel {
+	compatible = "apple,panel-j613", "apple,panel";
+	width-mm = <290>;
+	height-mm = <189>;
+	adj-height-mm = <181>;
+};
+
 &wifi0 {
 	brcm,board-type = "apple,dnieper";
 };

--- a/arch/arm64/boot/dts/apple/t8122-j615.dts
+++ b/arch/arm64/boot/dts/apple/t8122-j615.dts
@@ -31,6 +31,13 @@
 	};
 };
 
+&panel {
+	compatible = "apple,panel-j615", "apple,panel";
+	width-mm = <290>; // TODO
+	height-mm = <189>; // TODO
+	adj-height-mm = <181>;
+};
+
 &aop_mbox {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/apple/t8122-jxxx.dtsi
+++ b/arch/arm64/boot/dts/apple/t8122-jxxx.dtsi
@@ -62,6 +62,13 @@
 	};
 };
 
+&dcp {
+	panel: panel {
+		apple,max-brightness = <500>;
+	};
+};
+
+
 &serial0 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/apple/t8122-jxxx.dtsi
+++ b/arch/arm64/boot/dts/apple/t8122-jxxx.dtsi
@@ -26,6 +26,11 @@
 		usb4_0_nhi = &usb4_0_nhi;
 		usb4_1_rc = &usb4_1_acio;
 		usb4_1_nhi = &usb4_1_nhi;
+
+		dcp = &dcp;
+		disp0 = &display;
+                dcpext0 = &dcpext;
+		disp0_piodma = &disp_piodma;
 	};
 
 	chosen {

--- a/arch/arm64/boot/dts/apple/t8122.dtsi
+++ b/arch/arm64/boot/dts/apple/t8122.dtsi
@@ -364,6 +364,21 @@
 		clock-output-names = "nco_ref";
 	};
 
+	clk_disp: clock-disp {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <257142848>;
+		clock-output-names = "clk_disp";
+	};
+
+
+	clk_dispext0: clock-dispext0 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <0>;
+		clock-output-names = "clk_dispext0";
+	};
+
 	soc {
 		compatible = "simple-bus";
 		#address-cells = <2>;
@@ -650,6 +665,12 @@
 			};
 		};
 
+		pmgr_dcp: power-management@2d03d0000 {
+			reg = <0x2 0xd03d0000 0x0 0x4000>;
+			reg-names = "dcp-fw-pmgr";
+			#apple,bw-scratch-cells = <3>;
+		};
+
 		pmgr: power-management@2d0700000 {
 			compatible = "apple,t8122-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 			#address-cells = <1>;
@@ -909,6 +930,88 @@
 				     <AIC_IRQ 499 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
+
+		disp_dart: iommu@28d304000 {
+			compatible = "apple,t8122-dart", "apple,t8110-dart";
+			reg = <0x2 0x8d304000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 557 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+			power-domains = <&ps_disp_cpu>;
+			apple,dma-range = <0x100 0x0 0x10 0x0>;
+		};
+
+		dcp_dart: iommu@28d30c000 {
+			compatible = "apple,t8122-dart", "apple,t8110-dart";
+			reg = <0x2 0x8d30c000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 557 IRQ_TYPE_LEVEL_HIGH>;
+			power-domains = <&ps_disp_cpu>;
+			apple,dma-range = <0x100 0x0 0x10 0x0>;
+		};
+
+		dcp_mbox: mbox@28ec08000 {
+			compatible = "apple,t8122-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x8ec08000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 537 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 538 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 539 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 540 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			power-domains = <&ps_disp_cpu>;
+		};
+
+		dcp: dcp@28ec00000 {
+			compatible = "apple,t8122-dcp", "apple,dcp";
+			mboxes = <&dcp_mbox>;
+			mbox-names = "mbox";
+			iommus = <&dcp_dart 5>;
+			reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3", "disp-4";
+			reg = <0x2 0x8ec00000 0x0 0x4000>, // check?
+				<0x2 0x8c000000 0x0 0x690000>,
+                                <0x2 0x8c800000 0x0 0x690000>,
+				<0x2 0x8d320000 0x0 0x4000>,
+				<0x2 0x8d344000 0x0 0x4000>,
+				<0x2 0x8e800000 0x0 0x800000>;
+			apple,bw-scratch = <&pmgr_dcp 0 5 0x908>;
+			apple,iomfb-surfaces = <1 1 0 1>;
+			power-domains = <&ps_disp_cpu>;
+			resets = <&ps_disp_cpu>;
+			clocks = <&clk_disp>;
+			phandle = <&dcp>;
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
+
+			disp_piodma: piodma {
+				iommus = <&disp_dart 4>;
+				phandle = <&disp_piodma>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					/* dcp_audio: endpoint { */
+					/* 	remote-endpoint = <&dpaudio0_dcp>; */
+					/* }; */
+				};
+			};
+		};
+
+		display: display-subsystem {
+			compatible = "apple,display-subsystem";
+			iommus = <&disp_dart 0>;
+			/* generate phandle explicitly for use in loader */
+			phandle = <&display>;
+		};
+
 		aop_mbox: mbox@2f4408000 {
 			compatible = "apple,t8122-asc-mailbox", "apple,asc-mailbox-v4";
 			reg = <0x2 0xf4408000 0x0 0x4000>;
@@ -1114,6 +1217,82 @@
 			power-domains = <&ps_ans>, <&ps_apcie_st>;
 			power-domain-names = "ans", "apcie0";
 			resets = <&ps_ans>;
+		};
+
+		dispext0_dart: iommu@319304000 {
+			compatible = "apple,t8122-dart", "apple,t8110-dart";
+			reg = <0x3 0x19304000 0x0 0x4000>;
+			#iommu-cells = <5>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 599 IRQ_TYPE_LEVEL_HIGH>;
+			power-domains = <&ps_dispext_cpu>;
+			status = "disabled";
+		};
+
+		dcpext_dart: iommu@31930c000 {
+			compatible = "apple,t8122-dart", "apple,t8110-dart";
+			reg = <0x3 0x1930c000 0x0 0x4000>;
+			#iommu-cells = <5>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 599 IRQ_TYPE_LEVEL_HIGH>;
+			power-domains = <&ps_dispext_cpu>;
+			status = "disabled";
+		};
+
+		dcpext_mbox: mbox@31ac08000 {
+			compatible = "apple,t8122-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x3 0x1ac08000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 582 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 583 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 584 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 585 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			power-domains = <&ps_dispext_cpu>;
+			resets = <&ps_dispext_cpu>;
+			status = "disabled";
+		};
+
+		dcpext: dcp@31ac00000 {
+			compatible = "apple,t8122-dcpext", "apple,dcpext";
+			mboxes = <&dcpext_mbox>;
+			mbox-names = "mbox";
+			iommus = <&dcpext_dart 5 0x8 0x00000000 0x7 0xffff0000>;
+			phandle = <&dcpext>;
+
+			reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+			reg = <0x3 0x1ac00000 0x0 0x4000>,
+			      <0x3 0x18000000 0x0 0x690000>,
+			      <0x3 0x19320000 0x0 0x4000>,
+			      <0x3 0x19344000 0x0 0x4000>,
+			      <0x3 0x1a800000 0x0 0x800000>;
+			apple,bw-scratch = <&pmgr_dcp 0 4 910>;
+			apple,iomfb-surfaces = <1 1 0 1>;
+			power-domains = <&ps_dispext_cpu>;
+			resets = <&ps_dispext_cpu>;
+			clocks = <&clk_dispext0>;
+			apple,dcp-index = <1>;
+			status = "disabled";
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
+
+			piodma {
+				iommus = <&dispext0_dart 4 0x0 0x0 0xf 0xffff0000>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					/* dcpext_audio: endpoint { */
+					/* 	remote-endpoint = <&dpaudio1_dcp>; */
+					/* }; */
+				};
+			};
 		};
 
 		pcie0: pcie@580000000 {


### PR DESCRIPTION
there is some overlap with #607

it will not work withouth https://github.com/AsahiLinux/linux/pull/607/changes/62bd293cb0a47f6807e5019f3a905a529a0f94d8

It also needs m1n1 changes, for t6030 i needed:
```diff
diff --git a/src/kboot.c b/src/kboot.c
index 17c650eb..756092a2 100644
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -2018,7 +2018,8 @@ static int dt_set_display(void)
             }
         }
     } else if (!fdt_node_check_compatible(dt, 0, "apple,t6020") ||
-               !fdt_node_check_compatible(dt, 0, "apple,t6021")) {
+               !fdt_node_check_compatible(dt, 0, "apple,t6021") ||
+              !fdt_node_check_compatible(dt, 0, "apple,t6030")) {
         ret = dt_carveout_reserved_regions("dcp", "disp0", disp0_piodma_alias,
                                            disp_reserved_regions_t602x,
                                            ARRAY_SIZE(disp_reserved_regions_t602x));
@@ -2040,7 +2041,8 @@ static int dt_set_display(void)
     if (!fdt_node_check_compatible(dt, 0, "apple,t8112") ||
         !fdt_node_check_compatible(dt, 0, "apple,t6020") ||
         !fdt_node_check_compatible(dt, 0, "apple,t6021") ||
-        !fdt_node_check_compatible(dt, 0, "apple,t6022"))
+        !fdt_node_check_compatible(dt, 0, "apple,t6022") ||
+        !fdt_node_check_compatible(dt, 0, "apple,t6030"))
         dt_reserve_dcpext_firmware();
 
     const display_config_t *disp_cfg = display_get_config();
```